### PR TITLE
docs: add PR and issue template drafts

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,38 @@
+<!-- Bug report template for DattoRMM.Core -->
+
+---
+name: Bug report
+about: Create a report to help us improve
+title: ""
+labels: bug
+assignees: ''
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Run command '...'
+3. Observe error
+
+**Expected behavior**
+What you expected to happen.
+
+**Actual behavior**
+What actually happened, including error messages and stack traces.
+
+**Environment (please complete the following information):**
+- PowerShell version: (e.g. `7.4`)
+- DattoRMM.Core version: (if known)
+- Platform: Windows / Linux / Mac
+
+**Logs / Repro script**
+Paste any relevant logs, sanitized request/response samples, or a minimal repro script.
+
+**Workaround**
+If you have a temporary workaround, describe it.
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,30 @@
+<!-- Feature request template for DattoRMM.Core -->
+
+---
+name: Feature request
+about: Suggest an enhancement or new capability
+title: ""
+labels: enhancement
+assignees: ''
+---
+
+**Summary**
+A concise description of the requested feature.
+
+**Problem statement**
+Describe the problem this feature would solve and how it affects users.
+
+**Proposed solution**
+Describe your suggested implementation at a high level.
+
+**Alternatives considered**
+List other approaches considered and why they were rejected.
+
+**Acceptance criteria**
+Describe how you'll verify the feature is implemented (behavioural tests, manual checks).
+
+**Impact / Backwards compatibility**
+Describe any potential breaking changes, migration steps, or performance concerns.
+
+**Additional context**
+Any other notes, links, or mockups.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,64 @@
+<!-- Pull Request template for DattoRMM.Core
+
+Use this when opening a PR. Keep the Title concise and fill the sections below.
+-->
+
+## Summary
+
+Provide a short, one-line summary of the change.
+
+## Related issues
+
+List any related issue numbers (use `Fixes #<number>` to automatically close on merge).
+
+Example:
+
+- Fixes #27
+- Fixes #28
+
+## Changes
+
+Describe the key changes in this PR. Group by issue if this PR resolves multiple issues.
+
+- Issue #27: Short description of the fix
+- Issue #28: Short description of the fix
+
+## How to test
+
+Provide step-by-step instructions to verify the change locally.
+
+Examples:
+
+```powershell
+# Import the module (from repo root)
+Import-Module .\DattoRMM.Core\DattoRMM.Core.psm1 -Force
+
+# Run documentation coverage check
+.\Build\Get-ClassDocStatus.ps1
+
+# (If repo uses Pester tests)
+Invoke-Pester -Verbose
+```
+
+Manual checks:
+
+- Call the affected functions (e.g., `Get-RMMAlert -AlertUid <uid>`) and verify expected behaviour.
+
+## Checklist (required before requesting review)
+
+- [ ] Commits are scoped and named per repository conventions (one logical change per commit)
+- [ ] Linter/formatter run (e.g. `Invoke-ScriptAnalyzer`) and no new findings introduced
+- [ ] `Build\Get-ClassDocStatus.ps1` reports 0 gaps for class documentation (if classes changed)
+- [ ] Tests pass (Pester) or manual test steps verified
+- [ ] Relevant docs/help files updated (if public API or behaviour changed)
+- [ ] PR description references related issue(s) with `Fixes #<num>` where applicable
+
+## Notes / Breaking changes
+
+List any backwards-incompatible changes or migration steps for users.
+
+## Reviewers / Labels / Milestone (optional)
+
+- Request reviewer(s): @maintainer-handle
+- Suggested labels: `bug`, `enhancement`, `documentation`
+- Milestone: `v0.6.0-beta.1` (if applicable)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -731,6 +731,8 @@ refactor: Simplify pagination logic in Invoke-ApiMethod
 5. **Test your changes** — verify with a live API key pair if possible.
 6. **Describe your changes** — explain what changed, why, and what testing was done.
 
+**Templates:** The repository includes PR and issue templates to standardise contributions. Use the PR template when opening pull requests (see `.github/PULL_REQUEST_TEMPLATE.md`) — it includes sections for summary, related issues, change details, test instructions, and a pre-merge checklist. For new issues, use the templates under `.github/ISSUE_TEMPLATE/` (for example `bug_report.md` and `feature_request.md`). These templates help reviewers and maintainers triage and validate contributions more quickly.
+
 ---
 
 ## Security


### PR DESCRIPTION
## Summary
Add standardized PR and issue templates (draft) to improve contribution experience.

## Changes
- Added `.github/PULL_REQUEST_TEMPLATE.md` — template for opening PRs
- Added `.github/ISSUE_TEMPLATE/bug_report.md` — bug report template
- Added `.github/ISSUE_TEMPLATE/feature_request.md` — feature request template
- Updated `CONTRIBUTING.md` to reference the templates

## How to test
1. Go to your fork and click "New Issue" — you should see the issue templates listed.
2. Go to your fork and click "New pull request" — you should see the PR template auto-filled.

## Checklist
- [x] Single logical change (documentation/meta)
- [x] No linting or build issues
- [x] CONTRIBUTING.md updated with reference