### PR TITLE
fix: Fix alerts, site and token bugs; bump version to v0.5.52

### DIFF
--- a/DattoRMM.Core/DattoRMM.Core.psd1
+++ b/DattoRMM.Core/DattoRMM.Core.psd1
@@ -8,7 +8,7 @@
 RootModule = 'DattoRMM.Core.psm1'
 
 # Version number of this module. 
-ModuleVersion = '0.5.51'
+ModuleVersion = '0.5.52'
 
 # Supported PSEditions
 CompatiblePSEditions = @('Core')

--- a/DattoRMM.Core/DattoRMM.Core.psm1
+++ b/DattoRMM.Core/DattoRMM.Core.psm1
@@ -71,7 +71,9 @@ $Script:ConfigTokenExpireHours = $null
 $Script:ConfigApiMaxRetries = $null
 $Script:ConfigApiRetryIntervalSeconds = $null
 $Script:ConfigApiTimeoutSeconds = $null
+$Script:ConfigTokenRefreshBufferMinutes = $null
 $Script:TokenExpireHours = 100
+$Script:TokenRefreshBufferMinutes = 10
 $Script:MaxPageSize = $null
 
 # Establish module-level config file path (used by Read-ConfigFile, Write-ConfigFile, and related functions)

--- a/DattoRMM.Core/Private/Api/Invoke-ApiMethod.ps1
+++ b/DattoRMM.Core/Private/Api/Invoke-ApiMethod.ps1
@@ -53,10 +53,12 @@ function Invoke-ApiMethod {
 
     }
 
-    # Check token expiration (UTC comparison)
+    # Check token expiration with buffer (UTC comparison)
+    # Refresh proactively before expiry to prevent mid-pagination failures
     $Now = [datetime]::UtcNow
+    $RefreshThreshold = $script:RMMAuth.ExpiresAt.AddMinutes(-$Script:TokenRefreshBufferMinutes)
 
-    if ($Now -gt $script:RMMAuth.ExpiresAt) {
+    if ($Now -gt $RefreshThreshold) {
 
         if ($script:RMMAuth.AutoRefresh) {
 

--- a/DattoRMM.Core/Private/Api/Invoke-ApiRestMethod.ps1
+++ b/DattoRMM.Core/Private/Api/Invoke-ApiRestMethod.ps1
@@ -28,6 +28,7 @@ function Invoke-ApiRestMethod {
     $Attempt = 0
     $Success = $false
     $LastError = $null
+    $TokenRefreshAttempted = $false
 
     # Retry loop
     while (-not $Success -and $Attempt -le $Script:ApiMethodRetry.MaxRetries) {
@@ -98,10 +99,46 @@ function Invoke-ApiRestMethod {
 
                 401 {
 
-                    # Terminating condition no retry
-                    $Generic = "Authorization failed. Please check your credentials."
-                    $ShouldRetry = $false
+                    # Reactive token refresh — safety net for mid-request expiry (e.g., during long pagination runs)
+                    if (-not $TokenRefreshAttempted -and $script:RMMAuth.AutoRefresh) {
 
+                        Write-Verbose "Received 401. Attempting token refresh before failing."
+                        $TokenRefreshAttempted = $true
+
+                        $RefreshConnectParams = @{
+                            Key = $script:RMMAuth.Key
+                            Secret = $script:RMMAuth.Secret
+                            AutoRefresh = $true
+                        }
+
+                        switch ($Script:RMMAuth.Keys) {
+
+                            'Proxy' {$RefreshConnectParams.Proxy = $script:RMMAuth.Proxy}
+                            'ProxyCredential' {$RefreshConnectParams.ProxyCredential = $script:RMMAuth.ProxyCredential}
+
+                        }
+
+                        try {
+
+                            Connect-DattoRMM @RefreshConnectParams
+                            $Parameters.Headers = $script:RMMAuth.AuthHeader
+                            $Attempt--
+                            $ShouldRetry = $true
+
+                        } catch {
+
+                            $Generic = "Authorization failed. Token refresh also failed."
+                            $ShouldRetry = $false
+
+                        }
+
+                    } else {
+
+                        # Terminating condition no retry
+                        $Generic = "Authorization failed. Please check your credentials."
+                        $ShouldRetry = $false
+
+                    }
                 }
 
                 403 {

--- a/DattoRMM.Core/Private/Config/Initialize-SavedConfig.ps1
+++ b/DattoRMM.Core/Private/Config/Initialize-SavedConfig.ps1
@@ -68,6 +68,12 @@ function Initialize-SavedConfig {
                     Write-Verbose "ApiTimeoutSeconds: $($Script:ApiMethodRetry.TimeoutSeconds)"
                 }
 
+                'TokenRefreshBufferMinutes' {
+                    $Script:TokenRefreshBufferMinutes = $SavedConfig.TokenRefreshBufferMinutes
+                    $Script:ConfigTokenRefreshBufferMinutes = $SavedConfig.TokenRefreshBufferMinutes
+                    Write-Verbose "TokenRefreshBufferMinutes: $($Script:TokenRefreshBufferMinutes)"
+                }
+
                 'ThrottleProfile' {
 
                     Import-ThrottleProfile -Config $SavedConfig

--- a/DattoRMM.Core/Public/Alerts/Get-RMMAlert.ps1
+++ b/DattoRMM.Core/Public/Alerts/Get-RMMAlert.ps1
@@ -229,8 +229,13 @@ function Get-RMMAlert {
             $APIMethod = @{
                 Path = $MethodPath
                 Method = 'Get'
-                Paginate = $true
-                PageElement = 'alerts'
+            }
+
+            if ($PSCmdlet.ParameterSetName -ne 'Alert') {
+
+                $APIMethod.Paginate = $true
+                $APIMethod.PageElement = 'alerts'
+
             }
 
             Invoke-ApiMethod @APIMethod | ForEach-Object {

--- a/DattoRMM.Core/Public/Config/Get-RMMConfig.ps1
+++ b/DattoRMM.Core/Public/Config/Get-RMMConfig.ps1
@@ -59,6 +59,7 @@ function Get-RMMConfig {
         ConfiguredApiMaxRetries = $Script:ConfigApiMaxRetries
         ConfiguredApiRetryIntervalSeconds = $Script:ConfigApiRetryIntervalSeconds
         ConfiguredApiTimeoutSeconds = $Script:ConfigApiTimeoutSeconds
+        ConfiguredTokenRefreshBufferMinutes = $Script:ConfigTokenRefreshBufferMinutes
         SessionPlatform = $Script:SessionPlatform
         SessionPageSize = $Script:SessionPageSize
         SessionThrottleProfile = $Script:RMMThrottle.Profile
@@ -66,6 +67,7 @@ function Get-RMMConfig {
         SessionApiMaxRetries = $Script:ApiMethodRetry.MaxRetries
         SessionApiRetryIntervalSeconds = $Script:ApiMethodRetry.RetryIntervalSeconds
         SessionApiTimeoutSeconds = $Script:ApiMethodRetry.TimeoutSeconds
+        SessionTokenRefreshBufferMinutes = $Script:TokenRefreshBufferMinutes
     }
 
     return $ConfigInfo

--- a/DattoRMM.Core/Public/Config/Save-RMMConfig.ps1
+++ b/DattoRMM.Core/Public/Config/Save-RMMConfig.ps1
@@ -58,6 +58,7 @@ function Save-RMMConfig {
         'ApiMaxRetries' = $Script:ApiMethodRetry.MaxRetries
         'ApiRetryIntervalSeconds' = $Script:ApiMethodRetry.RetryIntervalSeconds
         'ApiTimeoutSeconds' = $Script:ApiMethodRetry.TimeoutSeconds
+        'TokenRefreshBufferMinutes' = $Script:TokenRefreshBufferMinutes
     }
 
     $Success = Write-ConfigFile -Config $Config
@@ -72,6 +73,7 @@ function Save-RMMConfig {
         $Script:ConfigApiMaxRetries = $Script:ApiMethodRetry.MaxRetries
         $Script:ConfigApiRetryIntervalSeconds = $Script:ApiMethodRetry.RetryIntervalSeconds
         $Script:ConfigApiTimeoutSeconds = $Script:ApiMethodRetry.TimeoutSeconds
+        $Script:ConfigTokenRefreshBufferMinutes = $Script:TokenRefreshBufferMinutes
 
         Write-Host "Configuration saved successfully." -ForegroundColor Green
 

--- a/DattoRMM.Core/Public/Config/Set-RMMConfig.ps1
+++ b/DattoRMM.Core/Public/Config/Set-RMMConfig.ps1
@@ -33,6 +33,9 @@ function Set-RMMConfig {
     .PARAMETER ApiTimeoutSeconds
         Sets the timeout in seconds for API requests. Valid range: 10-300. Default is 60. Use -Persist to save as the default for future sessions.
 
+    .PARAMETER TokenRefreshBufferMinutes
+        Sets the number of minutes before token expiry at which the module will proactively refresh the token. Valid range: 1-60. Default is 10. This prevents long-running paginated operations from failing due to mid-request token expiry. Use -Persist to save as the default for future sessions.
+
     .PARAMETER Persist
         If specified, saves the provided settings to the configuration file for future sessions. Without -Persist, changes apply only to the current session.
 
@@ -146,6 +149,14 @@ function Set-RMMConfig {
             ParameterSetName = 'Set',
             Mandatory = $false
         )]
+        [ValidateRange(1, 60)]
+        [int]
+        $TokenRefreshBufferMinutes,
+
+        [Parameter(
+            ParameterSetName = 'Set',
+            Mandatory = $false
+        )]
         [Parameter(
             ParameterSetName = 'Default',
             Mandatory = $false
@@ -195,6 +206,7 @@ function Set-RMMConfig {
 
         # Reset session variables to defaults
         $Script:TokenExpireHours = 100
+        $Script:TokenRefreshBufferMinutes = 10
         $Script:SessionPlatform = $null
         $Script:SessionPageSize = $null
         $Script:PageSize = $null
@@ -225,6 +237,7 @@ function Set-RMMConfig {
             $Script:ConfigApiMaxRetries = $null
             $Script:ConfigApiRetryIntervalSeconds = $null
             $Script:ConfigApiTimeoutSeconds = $null
+            $Script:ConfigTokenRefreshBufferMinutes = $null
 
         }
 
@@ -353,6 +366,18 @@ function Set-RMMConfig {
 
             }
         }
+
+        'TokenRefreshBufferMinutes' {
+
+            Write-Verbose "Set TokenRefreshBufferMinutes to: $TokenRefreshBufferMinutes"
+            $Script:TokenRefreshBufferMinutes = $TokenRefreshBufferMinutes
+
+            if ($Persist) {
+
+                $Config['TokenRefreshBufferMinutes'] = $TokenRefreshBufferMinutes
+
+            }
+        }
     }
 
     if ($Persist) {
@@ -390,6 +415,10 @@ function Set-RMMConfig {
 
                 'ApiTimeoutSeconds' {
                     $Script:ConfigApiTimeoutSeconds = $Script:ApiMethodRetry.TimeoutSeconds
+                }
+
+                'TokenRefreshBufferMinutes' {
+                    $Script:ConfigTokenRefreshBufferMinutes = $Script:TokenRefreshBufferMinutes
                 }
             }
 

--- a/DattoRMM.Core/Public/Sites/New-RMMSite.ps1
+++ b/DattoRMM.Core/Public/Sites/New-RMMSite.ps1
@@ -144,8 +144,8 @@ function New-RMMSite {
 
             'Description' {$Body.description = $Description}
             'Notes' {$Body.notes = $Notes}
-            'OnDemand' {$Body.onDemand = $true}
-            'SplashtopAutoInstall' {$Body.splashtopAutoInstall = $true}
+            'OnDemand' {$Body.onDemand = $OnDemand.IsPresent}
+            'SplashtopAutoInstall' {$Body.splashtopAutoInstall = $SplashtopAutoInstall.IsPresent}
         
         }
 
@@ -178,6 +178,7 @@ function New-RMMSite {
                     # Convert SecureString to plain text for API
                     $PlainPassword = ConvertFrom-SecureStringToPlaintext -SecureString $ProxyPassword
                     $ProxySettings.password = $PlainPassword
+                    $ClearPassword = $true
                     
                 }
             }
@@ -201,9 +202,13 @@ function New-RMMSite {
     end {
 
         # Clear plaintext password from memory
-        $PlainPassword = $null
-        $ProxySettings.password = $null
+        if ($ClearPassword -and $PlainPassword) {
 
+            $PlainPassword = $null
+            $ProxySettings.password = $null
+            [System.Runtime.InteropServices.Marshal]::ZeroFreeGlobalAllocUnicode([System.IntPtr]::Zero)
+
+        }
     }
 }
 

--- a/DattoRMM.Core/Public/Sites/Set-RMMSite.ps1
+++ b/DattoRMM.Core/Public/Sites/Set-RMMSite.ps1
@@ -9,8 +9,19 @@ function Set-RMMSite {
 
     .DESCRIPTION
         The Set-RMMSite function updates properties of an existing site in the authenticated
-        user's account. The site can be specified by passing a DRMMSite object from the pipeline
-        or by providing the SiteUid parameter directly.
+        user's account.
+
+        Due to an API limitation, omitted properties are wiped when updating a site. To prevent
+        unintended data loss, this function preserves existing property values by default:
+
+        - Pipeline input: When a DRMMSite object is piped, its current properties are used as
+          defaults for any parameters not explicitly specified.
+        - SiteUid input: When a site UID is provided, the function fetches the current site
+          state from the API and uses those values as defaults.
+
+        To bypass property preservation and send only explicitly specified parameters, use the
+        -OverwriteAll switch. When OverwriteAll is used, Name becomes mandatory and any omitted
+        properties will be reset to their API default values.
 
         Note: Proxy settings cannot be updated using this function. Use Set-RMMSiteProxy or
         Remove-RMMSiteProxy to manage proxy settings.
@@ -22,7 +33,8 @@ function Set-RMMSite {
         The unique identifier (GUID) of the site to update.
 
     .PARAMETER Name
-        The new name for the site. This parameter is required.
+        The new name for the site. Required when using -OverwriteAll. When a reference site
+        is available (pipeline or fetched), defaults to the existing site name.
 
     .PARAMETER Description
         The new description for the site.
@@ -36,13 +48,34 @@ function Set-RMMSite {
     .PARAMETER SplashtopAutoInstall
         Whether Splashtop should be automatically installed on devices at this site.
 
+    .PARAMETER AppendNotes
+        Append the value supplied to -Notes to the site's existing notes, separated by a blank
+        line. Requires -Notes to be specified. Has no effect if -Notes is not provided.
+
+        Not available with -OverwriteAll because the current site state is unknown in that
+        parameter set.
+
+    .PARAMETER OverwriteAll
+        Bypass property preservation and send only explicitly specified parameters to the API.
+        When this switch is used, Name becomes mandatory. Properties not explicitly specified
+        will be reset to their API default values.
+
+        Use this when you intentionally want to clear or reset site properties.
+
     .PARAMETER Force
         Suppress the confirmation prompt.
 
     .EXAMPLE
         Set-RMMSite -SiteUid "a1b2c3d4-e5f6-7890-abcd-ef1234567890" -Name "Updated Site Name"
 
-        Updates the name of the specified site.
+        Updates the site name. Other existing properties are preserved by fetching the current
+        site state from the API before updating.
+
+    .EXAMPLE
+        Set-RMMSite -SiteUid "a1b2c3d4-e5f6-7890-abcd-ef1234567890" -Name "Clean Site" -OverwriteAll
+
+        Updates the site with only the specified name. All other properties are reset to their
+        API default values because OverwriteAll bypasses property preservation.
 
     .EXAMPLE
         Get-RMMSite -Name "Old Name" | Set-RMMSite -Name "New Name" -Description "Updated description"
@@ -59,6 +92,11 @@ function Set-RMMSite {
         Get-RMMSite | Where-Object {$_.Name -like "Branch*"} | Set-RMMSite -SplashtopAutoInstall
 
         Enables Splashtop auto-install for all sites with names starting with "Branch".
+
+    .EXAMPLE
+        Get-RMMSite -SiteUid $SiteUid | Set-RMMSite -Notes "Reviewed April 2026" -AppendNotes
+
+        Appends a note to the site's existing notes, preserving the original content.
 
     .INPUTS
         DRMMSite. You can pipe site objects from Get-RMMSite.
@@ -86,7 +124,7 @@ function Set-RMMSite {
     .LINK
         Set-RMMSiteProxy
     #>
-    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Medium')]
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Medium', DefaultParameterSetName = 'BySiteObject')]
     param (
         [Parameter(
             ParameterSetName = 'BySiteObject',
@@ -100,16 +138,23 @@ function Set-RMMSite {
             ParameterSetName = 'ByUid',
             Mandatory = $true
         )]
+        [Parameter(
+            ParameterSetName = 'ByUidOverwrite',
+            Mandatory = $true
+        )]
         [Alias('Uid')]
         [guid]
         $SiteUid,
 
         [Parameter(
-            ParameterSetName = 'ByUid',
-            Mandatory = $true
+            ParameterSetName = 'ByUid'
         )]
         [Parameter(
             ParameterSetName = 'BySiteObject'
+        )]
+        [Parameter(
+            ParameterSetName = 'ByUidOverwrite',
+            Mandatory = $true
         )]
         [string]
         $Name,
@@ -130,6 +175,22 @@ function Set-RMMSite {
         [switch]
         $SplashtopAutoInstall,
 
+        [Parameter(
+            ParameterSetName = 'BySiteObject'
+        )]
+        [Parameter(
+            ParameterSetName = 'ByUid'
+        )]
+        [switch]
+        $AppendNotes,
+
+        [Parameter(
+            ParameterSetName = 'ByUidOverwrite',
+            Mandatory = $true
+        )]
+        [switch]
+        $OverwriteAll,
+
         [Parameter()]
         [switch]
         $Force
@@ -137,14 +198,36 @@ function Set-RMMSite {
 
     process {
 
-        if ($Site) {
+        # Resolve reference site for property preservation
+        switch ($PSCmdlet.ParameterSetName) {
 
-            $SiteUid = $Site.Uid
+            'BySiteObject' {
 
-            # Use existing values if not specified to prevent wiping them
-            $ParamsToCheck = @('Name', 'Description', 'Notes', 'OnDemand', 'SplashtopAutoInstall')
+                $SiteUid = $Site.Uid
+                $ReferenceSite = $Site
 
-            foreach ($ParamName in $ParamsToCheck) {
+            }
+
+            'ByUid' {
+
+                Write-Verbose "Fetching current site properties for preservation: $SiteUid"
+                $ReferenceSite = Get-RMMSite -SiteUid $SiteUid
+
+            }
+
+            'ByUidOverwrite' {
+
+                $ReferenceSite = $null
+
+            }
+        }
+
+        # Preserve existing values for any parameters not explicitly specified
+        if ($ReferenceSite) {
+
+            $PropertiesToPreserve = @('Name', 'Description', 'Notes', 'OnDemand', 'SplashtopAutoInstall')
+
+            foreach ($ParamName in $PropertiesToPreserve) {
 
                 if ($PSBoundParameters.ContainsKey($ParamName)) {
 
@@ -154,62 +237,61 @@ function Set-RMMSite {
 
                 switch ($ParamName) {
 
-                    'Name' {$Name = $Site.Name}
-                    'Description' {$Description = $Site.Description}
-                    'Notes' {$Notes = $Site.Notes}
-                    'OnDemand' {$OnDemand = $Site.OnDemand}
-                    'SplashtopAutoInstall' {$SplashtopAutoInstall = $Site.SplashtopAutoInstall}
-                    
+                    'Name' {$Name = $ReferenceSite.Name}
+                    'Description' {$Description = $ReferenceSite.Description}
+                    'Notes' {$Notes = $ReferenceSite.Notes}
+                    'OnDemand' {$OnDemand = $ReferenceSite.OnDemand}
+                    'SplashtopAutoInstall' {$SplashtopAutoInstall = $ReferenceSite.SplashtopAutoInstall}
+
                 }
             }
         }
 
-        if (-not $Force -and -not $PSCmdlet.ShouldProcess("Site $SiteUid", "Update site properties")) {
+        # Append new notes to existing notes if requested
+        if ($AppendNotes -and $PSBoundParameters.ContainsKey('Notes')) {
+
+            if ($ReferenceSite.Notes) {
+
+                $Notes = $ReferenceSite.Notes + "`n`n" + $Notes
+
+            }
+        }
+
+        if (-not $Force -and -not $PSCmdlet.ShouldProcess("Site $(if ($ReferenceSite) {$ReferenceSite.Name} else {$SiteUid})", "Update site properties")) {
 
             return
 
         }
 
-        Write-Debug "Updating RMM site: $SiteUid"
+        Write-Debug "Updating RMM site: $(if ($ReferenceSite) {$ReferenceSite.Name} else {$SiteUid})"
 
-        # Build request body - always include name
-        $Body = @{
-            name = $Name
-        }
+        # Build request body
+        if ($ReferenceSite) {
 
-        # Add description if it has a value
-        if ($PSBoundParameters.ContainsKey('Description') -or ($Site -and $Description)) {
+            # All properties included to prevent API from wiping unspecified values
+            $Body = @{
+                name = $Name
+                description = $Description
+                notes = $Notes
+                onDemand = [bool]$OnDemand
+                splashtopAutoInstall = [bool]$SplashtopAutoInstall
+            }
 
-            $Body.description = $Description
+        } else {
 
-        }
+            # No preservation - build body from explicit parameters only
+            $Body = @{
+                name = $Name
+            }
 
-        # Add notes if it has a value
-        if ($PSBoundParameters.ContainsKey('Notes') -or ($Site -and $Notes)) {
+            switch ($PSBoundParameters.Keys) {
 
-            $Body.notes = $Notes
+                'Description' {$Body.description = $Description}
+                'Notes' {$Body.notes = $Notes}
+                'OnDemand' {$Body.onDemand = $OnDemand.IsPresent}
+                'SplashtopAutoInstall' {$Body.splashtopAutoInstall = $SplashtopAutoInstall.IsPresent}
 
-        }
-
-        # Handle boolean fields - use .IsPresent for explicit params, direct value for piped site
-        if ($PSBoundParameters.ContainsKey('OnDemand')) {
-
-            $Body.onDemand = $OnDemand.IsPresent
-
-        } elseif ($Site -and $null -ne $OnDemand) {
-
-            $Body.onDemand = [bool]$OnDemand
-
-        }
-
-        if ($PSBoundParameters.ContainsKey('SplashtopAutoInstall')) {
-
-            $Body.splashtopAutoInstall = $SplashtopAutoInstall.IsPresent
-
-        } elseif ($Site -and $null -ne $SplashtopAutoInstall) {
-
-            $Body.splashtopAutoInstall = [bool]$SplashtopAutoInstall
-
+            }
         }
 
         $APIMethod = @{

--- a/docs/about/about_DattoRMM.CoreAuthentication.md
+++ b/docs/about/about_DattoRMM.CoreAuthentication.md
@@ -131,6 +131,8 @@ Connect-DattoRMM -Key "your-api-key" -Secret $Secret -AutoRefresh
 
 When `-AutoRefresh` is enabled, the module stores the supplied credentials in memory and uses them to request a new token before the current token expires. The default token lifetime is 100 hours and can be adjusted with `Set-RMMConfig -TokenExpireHours`.
 
+To protect long-running operations (such as paginating large device lists) from mid-request token expiry, the module refreshes the token proactively based on a configurable buffer. The default buffer is 10 minutes and can be adjusted with `Set-RMMConfig -TokenRefreshBufferMinutes`. As an additional safety net, if a 401 response is received during an API call, the module will attempt a single token refresh before failing.
+
 > [!IMPORTANT]
 > `-AutoRefresh` retains credentials in memory for the session. If this is not acceptable for your security posture, omit `-AutoRefresh` and re-authenticate manually when tokens expire.
 

--- a/docs/about/about_DattoRMM.CoreConfiguration.md
+++ b/docs/about/about_DattoRMM.CoreConfiguration.md
@@ -83,6 +83,16 @@ Controls how frequently the module refreshes its API token when `-AutoRefresh` i
 Set-RMMConfig -TokenExpireHours 48
 ```
 
+### Token Refresh Buffer Minutes
+
+Sets the number of minutes before token expiry at which the module will proactively refresh the token. This prevents long-running paginated operations (e.g., retrieving 100k+ devices) from failing due to mid-request token expiry. Valid range: 1–60. Default: 10.
+
+```powershell
+Set-RMMConfig -TokenRefreshBufferMinutes 15
+```
+
+As a safety net, the module also handles unexpected 401 responses during API calls by attempting a single token refresh (when `-AutoRefresh` is enabled) before failing. This covers edge cases such as clock skew or early token revocation.
+
 ### API Resilience Settings
 
 The module includes automatic retry logic for transient API failures:


### PR DESCRIPTION
### Summary

Patch release: bug fixes for alert pagination, site update behaviour, and token handling — plus module version bump to v0.5.52.

### Changes

- Issue #27 
    - Ensure single-alert retrieval path does not apply account/list pagination query params.
- Issue #28 
    - Fix pipeline/parameter-set handling so SiteUid usage receives the same safeguards as piped DRMMSite objects.
- Issue #9 
    - Ensure token refresh is attempted during long paginated fetches (when AutoRefresh enabled) and fail fast with clear message otherwise.

### Issues
- Fixxes [#9](https://github.com/TheShadowTek/DattoRMM.Core/issues/9)
- Fixes [#27](https://github.com/TheShadowTek/DattoRMM.Core/issues/27)
- Fixes [#28](https://github.com/TheShadowTek/DattoRMM.Core/issues/28)