### PR TITLE
feat: Add Export-RMMObjectCsv with transform-based CSV export system (#11)

### DIFF
--- a/DattoRMM.Core/DattoRMM.Core.psd1
+++ b/DattoRMM.Core/DattoRMM.Core.psd1
@@ -102,6 +102,7 @@ FormatsToProcess = @(
 FunctionsToExport = @(
     'Connect-DattoRMM',
     'Disconnect-DattoRMM',
+    'Export-RMMObjectCsv',
     'Get-RMMAccount',
     'Get-RMMActivityLog',
     'Get-RMMAlert',

--- a/DattoRMM.Core/DattoRMM.Core.psm1
+++ b/DattoRMM.Core/DattoRMM.Core.psm1
@@ -82,6 +82,9 @@ $Script:ConfigPath = Join-Path (Join-Path $HOME '.DattoRMM.Core') 'config.json'
 # Load and apply any saved configuration from disk
 Initialize-SavedConfig
 
+# Load built-in and user-defined export transforms
+Initialize-ExportTransforms
+
 # Module removal handler - cleanup module variables
 $MyInvocation.MyCommand.ScriptBlock.Module.OnRemove = {
 
@@ -104,6 +107,7 @@ $MyInvocation.MyCommand.ScriptBlock.Module.OnRemove = {
     Remove-Variable -Name ApiMethodRetry -Scope Script -ErrorAction SilentlyContinue
     Remove-Variable -Name ThrottleProfileDefaults -Scope Script -ErrorAction SilentlyContinue
     Remove-Variable -Name OperationMapping -Scope Script -ErrorAction SilentlyContinue
+    Remove-Variable -Name ExportTransforms -Scope Script -ErrorAction SilentlyContinue
     
 }
 

--- a/DattoRMM.Core/Private/Data/ExportTransforms.psd1
+++ b/DattoRMM.Core/Private/Data/ExportTransforms.psd1
@@ -1,0 +1,100 @@
+@{
+
+    'DRMMSite' = @{
+
+        'Default' = @(
+            'Id'
+            'Uid'
+            'Name'
+            'Description'
+            'OnDemand'
+            @{Name = 'TotalDevices'; Path = 'DevicesStatus.NumberOfDevices'}
+            @{Name = 'OnlineDevices'; Path = 'DevicesStatus.NumberOfOnlineDevices'}
+            @{Name = 'OfflineDevices'; Path = 'DevicesStatus.NumberOfOfflineDevices'}
+            'AutotaskCompanyName'
+            'AutotaskCompanyId'
+            'PortalUrl'
+        )
+
+        'Summary' = @(
+            'Id'
+            'Name'
+            'Description'
+            @{Name = 'TotalDevices'; Path = 'DevicesStatus.NumberOfDevices'}
+            @{Name = 'OnlineDevices'; Path = 'DevicesStatus.NumberOfOnlineDevices'}
+            @{Name = 'OfflineDevices'; Path = 'DevicesStatus.NumberOfOfflineDevices'}
+        )
+    }
+
+    'DRMMDevice' = @{
+
+        'Default' = @(
+            'Id'
+            'Uid'
+            'SiteId'
+            'SiteName'
+            'Hostname'
+            @{Name = 'DeviceCategory'; Path = 'DeviceType.Category'}
+            @{Name = 'DeviceTypeName'; Path = 'DeviceType.Type'}
+            'IntIpAddress'
+            'ExtIpAddress'
+            'OperatingSystem'
+            'Domain'
+            'LastLoggedInUser'
+            'Online'
+            'LastSeen'
+            'RebootRequired'
+            'Suspended'
+            'Deleted'
+            'WarrantyDate'
+            @{Name = 'AntivirusProduct'; Path = 'Antivirus.AntivirusProduct'}
+            @{Name = 'AntivirusStatus'; Path = 'Antivirus.AntivirusStatus'}
+            @{Name = 'PatchStatus'; Path = 'PatchManagement.PatchStatus'}
+            'PortalUrl'
+        )
+
+        'Summary' = @(
+            'Id'
+            'Hostname'
+            'SiteName'
+            'OperatingSystem'
+            'Online'
+            'LastSeen'
+            'IntIpAddress'
+        )
+    }
+
+    'DRMMAlert' = @{
+
+        'Default' = @(
+            'AlertUid'
+            'Priority'
+            'Diagnostics'
+            'Resolved'
+            'ResolvedBy'
+            'ResolvedOn'
+            'Muted'
+            'TicketNumber'
+            'Timestamp'
+            @{Name = 'AlertContextClass'; Path = 'AlertContext.Class'}
+            @{Name = 'MonitorSendsEmails'; Path = 'AlertMonitorInfo.SendsEmails'}
+            @{Name = 'MonitorCreatesTicket'; Path = 'AlertMonitorInfo.CreatesTicket'}
+            @{Name = 'DeviceName'; Path = 'AlertSourceInfo.DeviceName'}
+            @{Name = 'DeviceUid'; Path = 'AlertSourceInfo.DeviceUid'}
+            @{Name = 'SiteName'; Path = 'AlertSourceInfo.SiteName'}
+            @{Name = 'SiteUid'; Path = 'AlertSourceInfo.SiteUid'}
+            'AutoresolveMins'
+            'PortalUrl'
+        )
+
+        'Summary' = @(
+            'AlertUid'
+            'Priority'
+            'Resolved'
+            'Timestamp'
+            @{Name = 'DeviceName'; Path = 'AlertSourceInfo.DeviceName'}
+            @{Name = 'SiteName'; Path = 'AlertSourceInfo.SiteName'}
+            'Diagnostics'
+        )
+    }
+}

--- a/DattoRMM.Core/Private/Export/ConvertTo-ExportProperty.ps1
+++ b/DattoRMM.Core/Private/Export/ConvertTo-ExportProperty.ps1
@@ -1,0 +1,136 @@
+<#
+    Copyright (c) 2025-2026 Robert Faddes
+    SPDX-License-Identifier: MPL-2.0
+#>
+<#
+.SYNOPSIS
+    Converts export transform entries into Select-Object-compatible property definitions.
+.DESCRIPTION
+    Takes an array of transform entries from ExportTransforms.psd1 and converts them into
+    an array suitable for Select-Object -Property.
+
+    Simple string entries are passed through as direct property names.
+
+    Hashtable entries with a Name key support three resolution modes:
+
+    Path    — Dot-notation for nested property access (e.g. 'DevicesStatus.NumberOfDevices').
+              Also resolves ETS ScriptProperties added via Types.ps1xml.
+              Validated against ^[a-zA-Z_][a-zA-Z0-9_.]*$ to prevent injection.
+
+    Method  — A parameterless method name (e.g. 'GetSummary'). Resolves class methods and
+              ETS ScriptMethods added via Types.ps1xml.
+              Validated against ^[a-zA-Z_][a-zA-Z0-9_]*$ to prevent injection.
+
+    Expression — A string expression evaluated as a scriptblock (e.g. '$_.GetSummary()').
+                 Supports member access on $_, string operations, conditionals, and comparisons.
+                 Validated by Test-ExportExpression using layered security:
+                   1. Length cap (500 characters)
+                   2. ASCII character whitelist
+                   3. PowerShell AST parsing with whitelisted node types only
+                   4. Variable restriction ($_ $null $true $false only)
+                 Cmdlet calls, .NET type access, arbitrary variables, assignments,
+                 redirections, and scriptblock literals are blocked.
+
+    If a hashtable contains more than one of Path, Method, or Expression, the entry is
+    skipped with a warning.
+#>
+function ConvertTo-ExportProperty {
+    [CmdletBinding()]
+    param (
+
+        [Parameter(Mandatory = $true)]
+        [array]
+        $TransformEntries
+
+    )
+
+    $Properties = [System.Collections.Generic.List[object]]::new()
+
+    foreach ($Entry in $TransformEntries) {
+
+        if ($Entry -is [string]) {
+
+            $Properties.Add($Entry)
+
+        } elseif ($Entry -is [hashtable] -and $Entry.ContainsKey('Name')) {
+
+            $PropertyName = $Entry.Name
+
+            # Count how many resolution keys are present
+            $ResolutionKeys = @('Path', 'Method', 'Expression') | Where-Object {$Entry.ContainsKey($_)}
+
+            if ($ResolutionKeys.Count -ne 1) {
+
+                Write-Warning "Skipping transform property '$PropertyName': must contain exactly one of Path, Method, or Expression (found: $($ResolutionKeys -join ', '))"
+                continue
+
+            }
+
+            $Calculated = $null
+
+            if ($Entry.ContainsKey('Path')) {
+
+                $PropertyPath = $Entry.Path
+
+                # Validate path contains only safe property-access characters
+                if ($PropertyPath -notmatch '^[a-zA-Z_][a-zA-Z0-9_.]*$') {
+
+                    Write-Warning "Skipping transform property '$PropertyName': invalid path '$PropertyPath'"
+                    continue
+
+                }
+
+                $Calculated = @{
+                    Name = $PropertyName
+                    Expression = [scriptblock]::Create("`$_.$PropertyPath")
+                }
+
+            } elseif ($Entry.ContainsKey('Method')) {
+
+                $MethodName = $Entry.Method
+
+                # Validate method name contains only safe identifier characters
+                if ($MethodName -notmatch '^[a-zA-Z_][a-zA-Z0-9_]*$') {
+
+                    Write-Warning "Skipping transform property '$PropertyName': invalid method name '$MethodName'"
+                    continue
+
+                }
+
+                $Calculated = @{
+                    Name = $PropertyName
+                    Expression = [scriptblock]::Create("`$_.$MethodName()")
+                }
+
+            } elseif ($Entry.ContainsKey('Expression')) {
+
+                $ExpressionString = $Entry.Expression
+
+                # Layered validation: length, characters, AST nodes, variable restriction
+                if (-not (Test-ExportExpression -Expression $ExpressionString -PropertyName $PropertyName)) {
+
+                    continue
+
+                }
+
+                $Calculated = @{
+                    Name = $PropertyName
+                    Expression = [scriptblock]::Create($ExpressionString)
+                }
+            }
+
+            if ($Calculated) {
+
+                $Properties.Add($Calculated)
+
+            }
+
+        } else {
+
+            Write-Warning "Skipping unrecognised transform entry: $($Entry | ConvertTo-Json -Compress -Depth 1)"
+
+        }
+    }
+
+    return $Properties.ToArray()
+}

--- a/DattoRMM.Core/Private/Export/Initialize-ExportTransforms.ps1
+++ b/DattoRMM.Core/Private/Export/Initialize-ExportTransforms.ps1
@@ -1,0 +1,68 @@
+<#
+    Copyright (c) 2025-2026 Robert Faddes
+    SPDX-License-Identifier: MPL-2.0
+#>
+<#
+.SYNOPSIS
+    Loads built-in and user-defined export transforms into module state.
+.DESCRIPTION
+    Reads the built-in ExportTransforms.psd1 from Private/Data and optionally merges
+    user-defined transforms from $HOME/.DattoRMM.Core/ExportTransforms.psd1.
+
+    User transforms are additive. A user entry with the same class and transform name
+    as a built-in entry will override the built-in version.
+
+    The merged result is stored in $Script:ExportTransforms for use by Export-RMMObjectCsv.
+#>
+function Initialize-ExportTransforms {
+    [CmdletBinding()]
+    param ()
+
+    # Load built-in transforms
+    $BuiltInPath = Join-Path $PSScriptRoot '..\Data\ExportTransforms.psd1'
+
+    if (Test-Path $BuiltInPath) {
+
+        $Script:ExportTransforms = Import-PowerShellDataFile -Path $BuiltInPath
+        Write-Debug "Loaded built-in export transforms from $BuiltInPath"
+
+    } else {
+
+        $Script:ExportTransforms = @{}
+        Write-Warning "Built-in export transforms file not found at $BuiltInPath"
+
+    }
+
+    # Load user-defined transforms from profile directory
+    $UserPath = Join-Path (Join-Path $HOME '.DattoRMM.Core') 'ExportTransforms.psd1'
+
+    if (Test-Path $UserPath) {
+
+        try {
+
+            $UserTransforms = Import-PowerShellDataFile -Path $UserPath
+            Write-Verbose "Loading user export transforms from $UserPath"
+
+            foreach ($TypeName in $UserTransforms.Keys) {
+
+                if (-not $Script:ExportTransforms.ContainsKey($TypeName)) {
+
+                    $Script:ExportTransforms[$TypeName] = @{}
+
+                }
+
+                foreach ($TransformName in $UserTransforms[$TypeName].Keys) {
+
+                    $Script:ExportTransforms[$TypeName][$TransformName] = $UserTransforms[$TypeName][$TransformName]
+                    Write-Debug "User transform loaded: $TypeName/$TransformName"
+
+                }
+            }
+
+        } catch {
+
+            Write-Warning "Failed to load user export transforms from $UserPath`: $($_.Exception.Message)"
+
+        }
+    }
+}

--- a/DattoRMM.Core/Private/Export/Test-ExportExpression.ps1
+++ b/DattoRMM.Core/Private/Export/Test-ExportExpression.ps1
@@ -1,0 +1,133 @@
+<#
+    Copyright (c) 2025-2026 Robert Faddes
+    SPDX-License-Identifier: MPL-2.0
+#>
+<#
+.SYNOPSIS
+    Validates an expression string for safe use in export transforms.
+.DESCRIPTION
+    Applies layered security validation to an expression string before it is converted
+    to a scriptblock by ConvertTo-ExportProperty.
+
+    Layer 1 — Length gate: rejects expressions longer than 500 characters.
+    Layer 2 — Character whitelist: rejects expressions containing characters outside a
+              safe ASCII set (letters, digits, common punctuation, comparison operators).
+    Layer 3 — AST validation: parses the expression with the PowerShell parser and walks
+              the entire AST tree. Only whitelisted node types are permitted. This blocks
+              cmdlet/function calls, .NET type access, assignment statements, redirections,
+              and scriptblock literals.
+    Layer 4 — Variable restriction: only $_, $null, $true, and $false are permitted.
+              Access to arbitrary variables ($env:, $Host, $Error, etc.) is blocked.
+
+    Returns $true if the expression passes all layers, $false otherwise.
+    Writes a verbose message describing the first failing layer.
+
+    This function does not create or execute a scriptblock. It only validates.
+#>
+function Test-ExportExpression {
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param (
+
+        [Parameter(Mandatory = $true)]
+        [string]
+        $Expression,
+
+        [Parameter(Mandatory = $true)]
+        [string]
+        $PropertyName
+
+    )
+
+    # Layer 1: Length gate
+    if ($Expression.Length -gt 500) {
+
+        Write-Warning "Skipping transform property '$PropertyName': expression exceeds 500 character limit ($($Expression.Length) characters)"
+        return $false
+
+    }
+
+    # Layer 2: ASCII character whitelist (fast gate before parsing)
+    # Allows: letters, digits, underscore, whitespace, dot, $, (), {}, [], quotes,
+    # backtick, comma, hyphen, colon, pipe, /, semicolon, =, !, <, >, ?, #, @, +, *, %
+    if ($Expression -notmatch '^[A-Za-z0-9_\s\.\$\(\)\{\}\[\]''\"`,\-\:\|\/\;\=\!\<\>\?\#\@\+\*\%]+$') {
+
+        Write-Warning "Skipping transform property '$PropertyName': expression contains disallowed characters"
+        return $false
+
+    }
+
+    # Layer 3: AST validation — parse and walk the tree
+    $ParseErrors = $null
+    $Tokens = $null
+    $Ast = [System.Management.Automation.Language.Parser]::ParseInput(
+        $Expression,
+        [ref]$Tokens,
+        [ref]$ParseErrors
+    )
+
+    if ($ParseErrors.Count -gt 0) {
+
+        Write-Warning "Skipping transform property '$PropertyName': expression has syntax errors ($($ParseErrors[0].Message))"
+        return $false
+
+    }
+
+    # Whitelisted AST node types — only structural, access, and conditional nodes
+    $AllowedNodeTypes = @(
+        'ScriptBlockAst'
+        'NamedBlockAst'
+        'StatementBlockAst'
+        'PipelineAst'
+        'CommandExpressionAst'
+        'MemberExpressionAst'
+        'InvokeMemberExpressionAst'
+        'VariableExpressionAst'
+        'StringConstantExpressionAst'
+        'ExpandableStringExpressionAst'
+        'ConstantExpressionAst'
+        'BinaryExpressionAst'
+        'UnaryExpressionAst'
+        'IfStatementAst'
+        'ParenExpressionAst'
+        'SubExpressionAst'
+        'ArrayExpressionAst'
+        'ArrayLiteralAst'
+        'IndexExpressionAst'
+        'HashtableAst'
+        'HashtablePairAst'
+        'TernaryExpressionAst'
+    )
+
+    # Allowed variable names — only pipeline object and PowerShell built-in constants
+    $AllowedVariables = @('_', 'null', 'true', 'false')
+
+    $AstNodesAll = $Ast.FindAll({$true}, $true)
+
+    foreach ($Node in $AstNodesAll) {
+
+        $NodeTypeName = $Node.GetType().Name
+
+        if ($NodeTypeName -notin $AllowedNodeTypes) {
+
+            Write-Warning "Skipping transform property '$PropertyName': expression contains disallowed construct '$NodeTypeName'"
+            return $false
+
+        }
+
+        # Layer 4: Variable restriction
+        if ($Node -is [System.Management.Automation.Language.VariableExpressionAst]) {
+
+            if ($Node.VariablePath.UserPath -notin $AllowedVariables) {
+
+                Write-Warning "Skipping transform property '$PropertyName': expression references disallowed variable '`$$($Node.VariablePath.UserPath)'"
+                return $false
+
+            }
+        }
+    }
+
+    Write-Debug "Expression validated for '$PropertyName': $Expression"
+    return $true
+    
+}

--- a/DattoRMM.Core/Public/Export/Export-RMMObjectCsv.ps1
+++ b/DattoRMM.Core/Public/Export/Export-RMMObjectCsv.ps1
@@ -1,0 +1,389 @@
+<#
+    Copyright (c) 2025-2026 Robert Faddes
+    SPDX-License-Identifier: MPL-2.0
+#>
+function Export-RMMObjectCsv {
+    <#
+    .SYNOPSIS
+        Exports DattoRMM.Core objects to a flattened CSV file using named transforms.
+
+    .DESCRIPTION
+        The Export-RMMObjectCsv function accepts DattoRMM.Core objects via pipeline (or -InputObject),
+        detects the object type automatically, applies a named transform to flatten nested properties,
+        and writes each row directly to a CSV file for low memory usage.
+
+        Built-in transforms are provided for DRMMSite, DRMMDevice, and DRMMAlert. Each type includes a
+        'Default' and 'Summary' transform. The -TransformName parameter supports tab completion and
+        defaults to 'Default' if not specified.
+
+        Users can define custom transforms for any DattoRMM.Core class by creating an
+        ExportTransforms.psd1 file in $HOME/.DattoRMM.Core/. Custom transforms are merged with built-in
+        transforms at module load. A user entry with the same class and transform name as a built-in
+        entry will override the built-in version.
+
+        For DRMMDevice exports, the -IncludeUdf and -Udf parameters control whether user-defined
+        fields are appended to the transform output. By default, UDFs are excluded to keep exports
+        clean. -IncludeUdf adds all UDF columns (Udf1-Udf30) for consistent schema across appends.
+        -Udf accepts a string array to include specific UDFs (e.g. 'Udf1', 'Udf5').
+
+        Objects are written to disk individually in the process block. This streaming approach keeps
+        memory usage constant regardless of pipeline size, making it safe for Azure Automation and
+        large exports.
+
+    .PARAMETER InputObject
+        The DattoRMM.Core object to export. Accepts pipeline input. All objects in a single pipeline
+        invocation must be the same type.
+
+    .PARAMETER Path
+        The file path for the CSV output. Parent directories must exist.
+
+    .PARAMETER Append
+        Appends to an existing CSV file instead of overwriting. The caller is responsible for ensuring
+        schema compatibility when appending.
+
+    .PARAMETER IncludeTimestamp
+        Adds an 'ExportTimestamp' column with the current UTC date and time to each row.
+
+    .PARAMETER IncludeUdf
+        Includes all user-defined fields (UDF1-UDF30) in the export for consistent column schema.
+        Only valid for DRMMDevice objects. Ignored for other types.
+
+    .PARAMETER Udf
+        Includes specific user-defined fields by name (e.g. 'Udf1', 'Udf5'). Only valid for
+        DRMMDevice objects. Ignored for other types.
+
+    .PARAMETER Force
+        Overwrites the output file without prompting if it already exists.
+
+    .EXAMPLE
+        Get-RMMSite | Export-RMMObjectCsv -Path .\Sites.csv
+
+        Exports all sites using the default transform.
+
+    .EXAMPLE
+        Get-RMMDevice | Export-RMMObjectCsv -Path .\Devices.csv -TransformName Summary
+
+        Exports all devices using the Summary transform (fewer columns).
+
+    .EXAMPLE
+        Get-RMMAlert -Status All | Export-RMMObjectCsv -Path .\Alerts.csv -IncludeTimestamp
+
+        Exports all alerts with a UTC timestamp column appended to each row.
+
+    .EXAMPLE
+        Get-RMMDevice | Export-RMMObjectCsv -Path .\Devices.csv -IncludeUdf
+
+        Exports all devices with all UDF columns (Udf1-Udf30) appended.
+
+    .EXAMPLE
+        Get-RMMDevice | Export-RMMObjectCsv -Path .\Devices.csv -Udf 'Udf1', 'Udf5', 'Udf10'
+
+        Exports all devices with specific UDF columns appended.
+
+    .EXAMPLE
+        Get-RMMSite | Export-RMMObjectCsv -Path .\Sites.csv -Append
+
+        Appends site data to an existing CSV file.
+
+    .INPUTS
+        DRMMObject. Accepts any DattoRMM.Core typed object via pipeline. Built-in transforms are
+        provided for DRMMSite, DRMMDevice, and DRMMAlert. Custom transforms can be defined for any class.
+
+    .OUTPUTS
+        None. Writes output to the specified CSV file.
+
+    .NOTES
+        Custom export transforms can be defined by creating an ExportTransforms.psd1 file in
+        $HOME/.DattoRMM.Core/. The file uses the same format as the built-in transforms:
+
+            @{
+                'DRMMSite' = @{
+                    'MyCustomView' = @(
+                        'Name'
+                        'Description'
+                        @{Name = 'Devices'; Path = 'DevicesStatus.NumberOfDevices'}
+                    )
+                }
+            }
+
+        Simple string entries become direct property names. Hashtable entries with Name and Path
+        keys support dot-notation for nested property access. User transforms are loaded at module
+        import and merged with built-in transforms. Restart the module to pick up changes.
+
+    .LINK
+        https://github.com/TheShadowTek/DattoRMM.Core/blob/main/docs/commands/Export/Export-RMMObjectCsv.md
+
+    .LINK
+        Get-RMMSite
+
+    .LINK
+        Get-RMMDevice
+
+    .LINK
+        Get-RMMAlert
+    #>
+
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
+    param (
+
+        [Parameter(
+            Mandatory = $true,
+            ValueFromPipeline = $true
+        )]
+        [DRMMObject]
+        $InputObject,
+
+        [Parameter(Mandatory = $true)]
+        [string]
+        $Path,
+
+        [Parameter()]
+        [switch]
+        $Append,
+
+        [Parameter()]
+        [switch]
+        $IncludeTimestamp,
+
+        [Parameter()]
+        [switch]
+        $IncludeUdf,
+
+        [Parameter()]
+        [string[]]
+        $Udf,
+
+        [Parameter()]
+        [switch]
+        $Force
+
+    )
+
+    dynamicparam {
+
+        $ParamDictionary = [System.Management.Automation.RuntimeDefinedParameterDictionary]::new()
+
+        # Build ValidateSet from all loaded transform names across all types
+        if ($Script:ExportTransforms -and $Script:ExportTransforms.Count -gt 0) {
+
+            $AllTransformNames = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+
+            foreach ($TypeKey in $Script:ExportTransforms.Keys) {
+
+                foreach ($TransformKey in $Script:ExportTransforms[$TypeKey].Keys) {
+
+                    [void]$AllTransformNames.Add($TransformKey)
+
+                }
+            }
+
+            if ($AllTransformNames.Count -gt 0) {
+
+                $TransformAttribute = [System.Management.Automation.ParameterAttribute]::new()
+                $TransformAttribute.Mandatory = $false
+
+                $ValidateSetAttribute = [System.Management.Automation.ValidateSetAttribute]::new([string[]]$AllTransformNames)
+
+                $AttributeCollection = [System.Collections.ObjectModel.Collection[System.Attribute]]::new()
+                $AttributeCollection.Add($TransformAttribute)
+                $AttributeCollection.Add($ValidateSetAttribute)
+
+                $TransformParam = [System.Management.Automation.RuntimeDefinedParameter]::new(
+                    'TransformName',
+                    [string],
+                    $AttributeCollection
+                )
+                $TransformParam.Value = 'Default'
+
+                $ParamDictionary.Add('TransformName', $TransformParam)
+
+            }
+        }
+
+        return $ParamDictionary
+
+    }
+
+    begin {
+
+        $Initialized = $false
+        $RowCount = 0
+        $DetectedTypeName = $null
+        $SelectProperties = $null
+        $ExportParams = $null
+
+        # Resolve dynamic parameter value
+        if ($PSBoundParameters.ContainsKey('TransformName')) {
+
+            $TransformName = $PSBoundParameters['TransformName']
+
+        } else {
+
+            $TransformName = 'Default'
+
+        }
+
+        # Resolve output path early — fail fast on bad paths
+        $ResolvedPath = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($Path)
+
+        # Handle file overwrite decision before any pipeline processing
+        if (-not $Append) {
+
+            Write-Debug "Output file: $ResolvedPath"
+
+            if ((Test-Path $ResolvedPath) -and -not $Force) {
+
+                if (-not $PSCmdlet.ShouldProcess($ResolvedPath, "Overwrite existing file")) {
+
+                    $Script:ExportCancelled = $true
+                    return
+
+                }
+            }
+
+            # Clear file so process block can append rows with consistent behaviour
+            if (Test-Path $ResolvedPath) {
+
+                Remove-Item -Path $ResolvedPath -Force
+                Write-Debug "Cleared existing file: $ResolvedPath"
+
+            }
+        }
+
+        $Script:ExportCancelled = $false
+
+    }
+
+    process {
+
+        if ($Script:ExportCancelled) {return}
+
+        $TypeName = $InputObject.GetType().Name
+
+        # First-object initialization: detect type, validate transform, build properties
+        if (-not $Initialized) {
+
+            $DetectedTypeName = $TypeName
+            Write-Verbose "Detected object type: $DetectedTypeName"
+
+            # Validate transform exists for the detected type
+            if (-not $Script:ExportTransforms.ContainsKey($DetectedTypeName)) {
+
+                Write-Error "No export transforms are defined for type '$DetectedTypeName'. Define a custom transform in $HOME/.DattoRMM.Core/ExportTransforms.psd1." -ErrorAction Stop
+                return
+
+            }
+
+            $TypeTransforms = $Script:ExportTransforms[$DetectedTypeName]
+
+            if (-not $TypeTransforms.ContainsKey($TransformName)) {
+
+                $AvailableNames = ($TypeTransforms.Keys | Sort-Object) -join ', '
+                Write-Error "Transform '$TransformName' is not defined for type '$DetectedTypeName'. Available transforms: $AvailableNames" -ErrorAction Stop
+                return
+
+            }
+
+            Write-Verbose "Using transform '$TransformName' for type '$DetectedTypeName'"
+
+            # Convert transform entries to Select-Object properties
+            $TransformEntries = $TypeTransforms[$TransformName]
+            $SelectProperties = ConvertTo-ExportProperty -TransformEntries $TransformEntries
+
+            # Handle UDF parameters for DRMMDevice
+            if ($DetectedTypeName -eq 'DRMMDevice') {
+
+                if ($IncludeUdf) {
+
+                    Write-Verbose "Including all UDF columns (Udf1-Udf30)"
+
+                    for ($i = 1; $i -le 30; $i++) {
+
+                        $UdfName = "Udf$i"
+
+                        $SelectProperties += @{
+                            Name = $UdfName
+                            Expression = [scriptblock]::Create("`$_.Udfs.$UdfName")
+                        }
+                    }
+
+                } elseif ($Udf) {
+
+                    Write-Verbose "Including specified UDFs: $($Udf -join ', ')"
+
+                    foreach ($UdfName in $Udf) {
+
+                        # Validate UDF name format
+                        if ($UdfName -notmatch '^Udf\d{1,3}$') {
+
+                            Write-Warning "Skipping invalid UDF name '$UdfName'. Expected format: Udf1, Udf2, ... Udf30."
+                            continue
+
+                        }
+
+                        $SelectProperties += @{
+                            Name = $UdfName
+                            Expression = [scriptblock]::Create("`$_.Udfs.$UdfName")
+                        }
+                    }
+                }
+
+            } elseif ($IncludeUdf -or $Udf) {
+
+                Write-Warning "-IncludeUdf and -Udf parameters are only applicable to DRMMDevice objects. Ignoring."
+
+            }
+
+            # Add timestamp column if requested
+            if ($IncludeTimestamp) {
+
+                $SelectProperties += @{
+                    Name = 'ExportTimestamp'
+                    Expression = {(Get-Date).ToUniversalTime().ToString('yyyy-MM-dd HH:mm:ss')}
+                }
+
+                Write-Verbose "ExportTimestamp column enabled"
+
+            }
+
+            # Build Export-Csv parameters — always append since begin block handles file creation
+            $ExportParams = @{
+                Path = $ResolvedPath
+                NoTypeInformation = $true
+                Encoding = 'UTF8'
+                Append = $true
+            }
+
+            $Initialized = $true
+
+            Write-Verbose "Exporting $DetectedTypeName objects to $ResolvedPath"
+
+        } elseif ($TypeName -ne $DetectedTypeName) {
+
+            Write-Error "Mixed object types are not supported. Expected '$DetectedTypeName' but received '$TypeName'." -ErrorAction Stop
+            return
+
+        }
+
+        # Stream each object directly to file
+        $InputObject | Select-Object $SelectProperties | Export-Csv @ExportParams
+
+        $RowCount++
+
+    }
+
+    end {
+
+        if ($Script:ExportCancelled) {return}
+
+        if ($RowCount -eq 0) {
+
+            Write-Verbose "No objects received; nothing to export."
+
+        } else {
+
+            Write-Verbose "Export complete: $RowCount rows written to $ResolvedPath"
+
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ A PowerShell module for the Datto RMM API v2. Provides typed, object-oriented ac
 - **Adaptive Throttling** — Automatic rate-limit management with configurable profiles (Aggressive, Medium, Cautious) for safe single or concurrent use.
 - **Secure by Default** — Credentials handled via `SecureString` and `PSCredential`; tokens held in memory only; PII-sensitive operations require explicit confirmation.
 - **Persistent Configuration** — Platform region, throttle profile, page size, and retry settings saved to a JSON config file for consistent behaviour across sessions.
-- **Comprehensive Coverage** — 42 commands across 11 domains: Account, Activity Log, Alerts, Auth, Components, Config, Devices, Filters, Jobs, Sites, and Variables.
+- **Opinionated CSV Export** — Export Sites, Devices, and Alerts to flattened CSV using named column transforms. Supports user defined transformations.
+- **Comprehensive Coverage** — 43 commands across 12 domains: Account, Activity Log, Alerts, Auth, Components, Config, Devices, Export, Filters, Jobs, Sites, and Variables.
 
 ## Installation
 
@@ -41,7 +42,7 @@ Get-RMMDevice
 Get-RMMSite -Name "Main Office" | Get-RMMAlert
 
 # Export all sites to CSV
-Get-RMMSite | Export-Csv Sites.csv
+Get-RMMSite | Export-RMMObjectCsv -Path .\Sites.csv
 ```
 
 For credential storage options (SecretStore, Azure Automation, Key Vault), see [Authentication](docs/about/about_DattoRMM.CoreAuthentication.md).
@@ -80,6 +81,7 @@ Get-RMMDevice -FilterId 12345 | New-RMMQuickJob -JobName "Emergency Patch" -Comp
 | **Components** | `Get-RMMComponent` |
 | **Config** | `Get-RMMConfig`, `Set-RMMConfig`, `Save-RMMConfig`, `Remove-RMMConfig` |
 | **Devices** | `Get-RMMDevice`, `Get-RMMDeviceAudit`, `Get-RMMDeviceSoftware`, `Get-RMMEsxiHostAudit`, `Get-RMMPrinterAudit`, `Move-RMMDevice`, `Set-RMMDeviceUDF`, `Set-RMMDeviceWarranty` |
+| **Export** | `Export-RMMObjectCsv` |
 | **Filters** | `Get-RMMFilter` |
 | **Jobs** | `Get-RMMJob`, `Get-RMMJobResult`, `New-RMMQuickJob` |
 | **Sites** | `Get-RMMSite`, `Get-RMMSiteSettings`, `New-RMMSite`, `Set-RMMSite`, `Set-RMMSiteProxy`, `Remove-RMMSiteProxy` |
@@ -99,6 +101,7 @@ Run `Get-Help <CommandName>` for detailed parameter and usage information, or se
 | [Configuration](docs/about/about_DattoRMM.CoreConfiguration.md) | Platform regions, page size, retry settings, and persistent configuration |
 | [Throttling](docs/about/about_DattoRMM.CoreThrottling.md) | Adaptive throttling, profiles, concurrent use, and API rate limit details |
 | [Security](docs/about/about_DattoRMM.CoreSecurity.md) | PII handling, credential lifecycle, SecureString cross-platform behaviour |
+| [Export](docs/about/about_DattoRMM.CoreExport.md) | CSV export, built-in transforms, custom transform authoring, UDF handling |
 | [Alert Context Discovery (Beta)](docs/about/about_DattoRMM.CoreAlertContextDiscovery.md) | Guidance for collecting unrecognised alert context schema data during beta |
 | [Beta Overview](docs/beta/about_DattoRMM.CoreBeta.md) | Beta status, expectations, and roadmap to v1 |
 | [Beta Guide](docs/beta/DattoRMM.Core-Beta-Guide.md) | Getting started with the beta, usage tips, and feedback |

--- a/docs/about/about_DattoRMM.Core.md
+++ b/docs/about/about_DattoRMM.Core.md
@@ -24,6 +24,7 @@ The DattoRMM.Core module provides an object-oriented interface to the Datto RMM 
 - **Auto-Pagination** — Paginated API endpoints are handled transparently, streaming results into the pipeline.
 - **Automatic Token Refresh** — Optional credential retention for long-running automation without manual re-authentication.
 - **API Resilience** — Configurable retry logic with exponential backoff for transient failures.
+- **Opinionated CSV Export** — Export typed objects to flattened CSV using named column transforms. Objects are streamed directly to disk, keeping memory usage constant regardless of pipeline size. Built-in transforms cover Sites, Devices, and Alerts. User-defined transforms extend the system to any class and are loaded automatically from the module profile folder.
 
 ### Module Architecture
 
@@ -31,7 +32,7 @@ The module follows a layered architecture:
 
 1. **Classes** — Domain models, request/response types, and enums defined in a single structured module (`Private/Classes/Classes.psm1`), loaded first via `using module`.
 2. **Private Helpers** — Integration logic, API invocation, throttling, and configuration management.
-3. **Public API** — 40 exported commands organised by domain, orchestrating private helpers and returning typed objects.
+3. **Public API** — 43 exported commands organised by domain, orchestrating private helpers and returning typed objects.
 
 Public functions are grouped by domain under `Public/<Domain>/` and are the only exported surface. Private functions handle all API communication and data transformation.
 
@@ -121,6 +122,17 @@ Manage account-level and site-level variables.
 - `Set-RMMVariable` — Update a variable's name or value.
 - `Remove-RMMVariable` — Permanently delete a variable.
 
+### Export
+Export typed objects to flattened CSV files using named transforms.
+
+- `Export-RMMObjectCsv` — Export Sites, Devices, or Alerts to CSV with built-in or custom transforms.
+
+`Export-RMMObjectCsv` accepts any `DRMMObject` via the pipeline, detects the type automatically, and applies a named column transform to flatten nested properties into a predictable CSV shape. Objects are written to disk one at a time, making it safe for large pipelines and Azure Automation environments with memory constraints.
+
+The `-TransformName` parameter is tab-completable and defaults to `'Default'`. Additional named transforms per type (e.g. `'Summary'`) are included. Users can define their own transforms for any class in `$HOME/.DattoRMM.Core/ExportTransforms.psd1`; these are merged at module load.
+
+See [about_DattoRMM.CoreExport](about_DattoRMM.CoreExport.md) for full details including transform authoring.
+
 ## PIPELINE PATTERNS
 
 The module is designed around pipeline chaining. Common patterns:
@@ -143,9 +155,9 @@ Get-RMMDevice -Hostname "SRV-*" | Get-RMMDeviceAudit
 Get-RMMSite -Name "Branch Office" | Get-RMMVariable
 
 # Bulk export
-Get-RMMSite | Export-Csv Sites.csv
-Get-RMMDevice | Export-Csv Devices.csv
-Get-RMMAlert -Status All | Export-Csv Alerts.csv
+Get-RMMSite | Export-RMMObjectCsv -Path .\Sites.csv
+Get-RMMDevice | Export-RMMObjectCsv -Path .\Devices.csv
+Get-RMMAlert -Status All | Export-RMMObjectCsv -Path .\Alerts.csv -IncludeTimestamp
 ```
 
 ## EXAMPLES
@@ -191,6 +203,7 @@ Set-RMMConfig -Platform Merlot -PageSize 100 -ThrottleProfile Medium -Persist
 - [about_DattoRMM.CoreConfiguration](about_DattoRMM.CoreConfiguration.md)
 - [about_DattoRMM.CoreThrottling](about_DattoRMM.CoreThrottling.md)
 - [about_DattoRMM.CoreSecurity](about_DattoRMM.CoreSecurity.md)
+- [about_DattoRMM.CoreExport](about_DattoRMM.CoreExport.md)
 - [Beta Overview](../beta/about_DattoRMM.CoreBeta.md)
 - [Beta Guide](../beta/DattoRMM.Core-Beta-Guide.md)
 - [Beta Examples](../beta/DattoRMM.Core-Beta-Examples.md)

--- a/docs/about/about_DattoRMM.CoreExport.md
+++ b/docs/about/about_DattoRMM.CoreExport.md
@@ -1,0 +1,357 @@
+# about_DattoRMM.CoreExport
+
+## SHORT DESCRIPTION
+
+Opinionated CSV export for DattoRMM.Core typed objects using named column transforms, with support for user-defined transforms loaded from the module profile folder.
+
+## LONG DESCRIPTION
+
+`Export-RMMObjectCsv` provides a structured, low-friction way to export `DRMMSite`, `DRMMDevice`, and `DRMMAlert` objects to CSV without requiring users to manually flatten nested properties using `Select-Object`. The command detects the object type from the pipeline, applies a named transform, and streams each row directly to disk.
+
+### Why a dedicated export command
+
+DattoRMM.Core objects are typed classes with rich nested structures. A `DRMMDevice` carries its site details, antivirus status, patch management state, and UDFs as nested objects. A `DRMMAlert` wraps source device and site information inside `AlertSourceInfo`. Passing these directly to `Export-Csv` produces columns containing class names rather than values.
+
+`Export-RMMObjectCsv` resolves this by applying a transform — a named, ordered list of column definitions — that flattens the object into a predictable, human-readable CSV shape.
+
+### The transform system
+
+A transform is a named array of column definitions stored in a `.psd1` file. Each transform belongs to a class name key, and each class can have multiple named transforms.
+
+**Column definition formats:**
+
+A simple string includes a direct property by name:
+
+```powershell
+'Hostname'
+'Online'
+'OperatingSystem'
+```
+
+A hashtable with `Name` and `Path` creates a calculated column using dot-notation for nested access. This also resolves ETS ScriptProperties added via `Types.ps1xml`:
+
+```powershell
+@{Name = 'DeviceCategory'; Path = 'DeviceType.Category'}
+@{Name = 'AntivirusStatus'; Path = 'Antivirus.AntivirusStatus'}
+@{Name = 'TotalDevices'; Path = 'DevicesStatus.NumberOfDevices'}
+```
+
+Paths are validated at runtime against `^[a-zA-Z_][a-zA-Z0-9_.]*$` before being converted to scriptblocks.
+
+A hashtable with `Name` and `Method` calls a parameterless method on the object. This resolves class methods and ETS ScriptMethods added via `Types.ps1xml`:
+
+```powershell
+@{Name = 'AlertSummary'; Method = 'GetSummary'}
+@{Name = 'DeviceAge'; Method = 'GetDeviceAge'}
+```
+
+Method names are validated against `^[a-zA-Z_][a-zA-Z0-9_]*$`.
+
+A hashtable with `Name` and `Expression` evaluates a string expression as a scriptblock. This supports member access on `$_`, string operations, conditionals, and comparison operators:
+
+```powershell
+@{Name = 'Status'; Expression = 'if ($_.Online) {"Online"} else {"Offline"}'}
+@{Name = 'CustomerId'; Expression = '$_.Name.Split(" - ")[0]'}
+@{Name = 'DisplayName'; Expression = '$_.Hostname.ToUpper()'}
+```
+
+Because `.psd1` data files cannot contain scriptblock literals (`{...}`), expressions are written as strings and converted to scriptblocks at runtime after passing layered security validation.
+
+**Expression security model:**
+
+Expressions are validated by `Test-ExportExpression` through four layers before conversion:
+
+| Layer | Check | Purpose |
+|---|---|---|
+| 1 | Length cap (500 characters) | Prevents abuse via excessively long expressions |
+| 2 | ASCII character whitelist | Fast rejection of unexpected character classes |
+| 3 | PowerShell AST parsing | Whitelists safe node types only; blocks cmdlet calls, .NET type access, assignments, redirections, and scriptblock literals |
+| 4 | Variable restriction | Only `$_`, `$null`, `$true`, and `$false` are permitted |
+
+**What is allowed in expressions:**
+
+- Property access on `$_` — `$_.Hostname`, `$_.Antivirus.AntivirusStatus`
+- Method calls on `$_` and its members — `$_.Hostname.ToUpper()`, `$_.Name.Split("-")[0]`
+- Comparisons — `$_.Value -gt 10`, `$_.Online -eq $true`
+- Conditionals — `if ($_.Online) {"Up"} else {"Down"}`
+- String interpolation — `"$($_.SiteName) - $($_.Hostname)"`
+- Ternary expressions — `$_.Online ? "Up" : "Down"`
+
+**What is blocked:**
+
+- Cmdlet or function calls (`Get-Date`, `Write-Host`, `Invoke-Expression`)
+- .NET type access (`[System.IO.File]::ReadAllText()`, `[DateTime]::Now`)
+- Arbitrary variables (`$env:COMPUTERNAME`, `$Host`, `$Error`, `$PSVersionTable`)
+- Assignment statements (`$x = 5`)
+- Redirections, pipeline commands, and nested scriptblock literals
+
+> If an expression requires cmdlets or .NET types, define a ScriptProperty or ScriptMethod in `Types.ps1xml` and reference it via `Path` or `Method` instead. For more complex transformations, write a custom export script outside the module.
+
+> Each hashtable entry must contain exactly one of `Path`, `Method`, or `Expression`. Entries with more than one are skipped with a warning.
+
+### Built-in transforms
+
+| Type | Transform | Description |
+|---|---|---|
+| `DRMMSite` | `Default` | Id, Uid, Name, Description, OnDemand, device counts, AutotaskCompanyName, AutotaskCompanyId, PortalUrl |
+| `DRMMSite` | `Summary` | Id, Name, Description, device counts |
+| `DRMMDevice` | `Default` | Id, Uid, site details, hostname, device type, IP addresses, OS, user, domain, online status, timestamps, warranty, antivirus, patch status, PortalUrl |
+| `DRMMDevice` | `Summary` | Id, Hostname, SiteName, OperatingSystem, Online, LastSeen, IntIpAddress |
+| `DRMMAlert` | `Default` | AlertUid, Priority, Diagnostics, resolution details, context class, monitor config, source device and site, AutoresolveMins, PortalUrl |
+| `DRMMAlert` | `Summary` | AlertUid, Priority, Resolved, Timestamp, DeviceName, SiteName, Diagnostics |
+
+### Selecting a transform
+
+The `-TransformName` parameter is tab-completable. Its `ValidateSet` is built dynamically from all loaded transforms — built-in and user-defined — when the function is invoked. It defaults to `'Default'` if not specified.
+
+```powershell
+Get-RMMDevice | Export-RMMObjectCsv -Path .\Devices.csv -TransformName Summary
+```
+
+### Memory efficiency
+
+Objects are written to disk one at a time in the `process` block. The file is created (or cleared) in `begin` before the pipeline starts. This streaming approach keeps memory usage flat regardless of how large the pipeline is, and is safe for Azure Automation runbooks and other memory-constrained environments.
+
+### The -Append parameter
+
+`-Append` writes new rows into an existing file without truncating it. File creation and overwrite decisions are made in `begin` — before any pipeline objects arrive — so a long-running export will not fail midway through on a file access conflict.
+
+When using `-Append`, the caller is responsible for ensuring the schema matches. Mixing a `Default` export with a `Summary` append will produce a malformed CSV.
+
+---
+
+## UDF HANDLING
+
+User-defined fields are excluded from the default transform to keep the output clean. Two parameters control UDF inclusion for `DRMMDevice` exports.
+
+### -IncludeUdf
+
+Includes all 30 UDF columns (Udf1–Udf30) in every row, regardless of whether they contain values. This produces a consistent, fixed-width schema across all rows, which is important when using `-Append` to combine exports from multiple runs:
+
+```powershell
+Get-RMMDevice | Export-RMMObjectCsv -Path .\Devices.csv -IncludeUdf
+```
+
+### -Udf
+
+Includes only the named UDFs. Useful when only a subset of fields are relevant and the schema is known:
+
+```powershell
+Get-RMMDevice | Export-RMMObjectCsv -Path .\Devices.csv -Udf 'Udf1', 'Udf5', 'Udf10'
+```
+
+Both parameters are ignored for all but `DRMMDevice` exports, other types produce a warning if specified.
+
+> When Datto RMM expands the UDF count in a future platform update, `-IncludeUdf` will include all new fields automatically once the class is updated.
+
+---
+
+## DEFINING CUSTOM TRANSFORMS
+
+Custom transforms are loaded from `$HOME/.DattoRMM.Core/ExportTransforms.psd1` at module import. They are merged with the built-in transforms. An entry with the same class and transform name as a built-in entry overrides the built-in version.
+
+The file uses the same format as the built-in `ExportTransforms.psd1`:
+
+```powershell
+@{
+
+    'DRMMSite' = @{
+
+        'Billing' = @(
+            'Name'
+            'AutotaskCompanyName'
+            'AutotaskCompanyId'
+            @{Name = 'TotalDevices'; Path = 'DevicesStatus.NumberOfDevices'}
+        )
+    }
+
+    'DRMMDevice' = @{
+
+        'Compliance' = @(
+            'Hostname'
+            'SiteName'
+            'OperatingSystem'
+            'RebootRequired'
+            @{Name = 'PatchStatus'; Path = 'PatchManagement.PatchStatus'}
+            @{Name = 'AntivirusStatus'; Path = 'Antivirus.AntivirusStatus'}
+            'WarrantyDate'
+        )
+    }
+}
+```
+
+After creating or editing the file, reimport the module to pick up the changes:
+
+```powershell
+Remove-Module DattoRMM.Core
+Import-Module .\DattoRMM.Core\DattoRMM.Core.psd1
+```
+
+### Transforms for any class
+
+The transform system is not limited to Site, Device, and Alert. You can define transforms for any DattoRMM.Core class that is returned from the API, including `DRMMActivityLog`, `DRMMComponent`, `DRMMFilter`, or `DRMMVariable`. The class name key must exactly match the PowerShell class name:
+
+```powershell
+@{
+
+    'DRMMActivityLog' = @{
+
+        'Default' = @(
+            'Id'
+            'Created'
+            'Username'
+            'Type'
+            'Description'
+        )
+    }
+}
+```
+
+Pipe the objects to `Export-RMMObjectCsv` as normal — the command detects the type and resolves the transform:
+
+```powershell
+Get-RMMActivityLog | Export-RMMObjectCsv -Path .\ActivityLog.csv
+```
+
+If no transform is defined for the detected type, a non-terminating error is raised on the first object and the export stops.
+
+### Using with type extensions
+
+Custom properties and methods added via `Types.ps1xml` are fully supported by the transform system.
+
+**ScriptProperty via Path** — A ScriptProperty defined in `Types.ps1xml` is accessed like any other property and can be referenced using `Path`:
+
+```xml
+<!-- Types.ps1xml -->
+<ScriptProperty>
+    <Name>DeviceAge</Name>
+    <GetScriptBlock>((Get-Date) - $this.LastSeen).Days</GetScriptBlock>
+</ScriptProperty>
+```
+
+```powershell
+# ExportTransforms.psd1
+@{Name = 'DeviceAge'; Path = 'DeviceAge'}
+```
+
+**ScriptMethod via Method** — A ScriptMethod defined in `Types.ps1xml` can be called using the `Method` key:
+
+```xml
+<!-- Types.ps1xml -->
+<ScriptMethod>
+    <Name>GetStatusLabel</Name>
+    <Script>if ($this.Online) {'Online'} else {'Offline'}</Script>
+</ScriptMethod>
+```
+
+```powershell
+# ExportTransforms.psd1
+@{Name = 'Status'; Method = 'GetStatusLabel'}
+```
+
+**Expression for inline logic** — When a ScriptProperty or ScriptMethod is not available (or not worth creating), use `Expression` for ad-hoc logic directly in the transform. Expressions are restricted to member access on `$_`, comparisons, string operations, and conditionals — cmdlet calls and .NET type access are blocked:
+
+```powershell
+# ExportTransforms.psd1
+@{Name = 'DisplayName';  Expression = '"$($_.SiteName) - $($_.Hostname)"'}
+@{Name = 'StatusLabel';   Expression = 'if ($_.Online) {"Up"} else {"Down"}'}
+@{Name = 'CustomerId'; Expression = '$_.Name.Split(" - ")[0]'}
+```
+
+> For expressions that require cmdlets (e.g., `Get-Date`) or .NET type access, define a ScriptProperty in `Types.ps1xml` instead and reference it via `Path`.
+
+> A future update will support dynamic loading of `Types.ps1xml` and `Format.ps1xml` files from the module profile folder alongside the custom transforms file.
+
+---
+
+## EXAMPLES
+
+### Example 1: Export all sites
+
+```powershell
+Get-RMMSite | Export-RMMObjectCsv -Path .\Sites.csv
+```
+
+### Example 2: Export devices with a compact column set
+
+```powershell
+Get-RMMDevice | Export-RMMObjectCsv -Path .\Devices.csv -TransformName Summary
+```
+
+### Example 3: Export all alerts with a UTC timestamp per row
+
+```powershell
+Get-RMMAlert -Status All | Export-RMMObjectCsv -Path .\Alerts.csv -IncludeTimestamp
+```
+
+### Example 4: Export devices with full UDF columns for consistent schema
+
+```powershell
+Get-RMMDevice | Export-RMMObjectCsv -Path .\Devices.csv -IncludeUdf
+```
+
+### Example 5: Append new device data to an existing file
+
+```powershell
+# Initial export
+Get-RMMSite -Name "Site A" | Get-RMMDevice | Export-RMMObjectCsv -Path .\AllDevices.csv
+
+# Append results from a second site with matching schema
+Get-RMMSite -Name "Site B" | Get-RMMDevice | Export-RMMObjectCsv -Path .\AllDevices.csv -Append
+```
+
+### Example 6: Export using a custom user-defined transform
+
+Assuming `$HOME/.DattoRMM.Core/ExportTransforms.psd1` defines a `'Compliance'` transform for `DRMMDevice`:
+
+```powershell
+Get-RMMDevice | Export-RMMObjectCsv -Path .\Compliance.csv -TransformName Compliance
+```
+
+### Example 7: Transform using a Method entry
+
+Assuming `DRMMAlert` has a `GetSummary()` method (class method or ETS ScriptMethod):
+
+```powershell
+# In ExportTransforms.psd1
+'DRMMAlert' = @{
+    'WithSummary' = @(
+        'AlertUid'
+        'Priority'
+        @{Name = 'AlertSummary'; Method = 'GetSummary'}
+        'Timestamp'
+    )
+}
+```
+
+```powershell
+Get-RMMAlert | Export-RMMObjectCsv -Path .\Alerts.csv -TransformName WithSummary
+```
+
+### Example 8: Transform using an Expression entry
+
+```powershell
+# In ExportTransforms.psd1
+'DRMMDevice' = @{
+    'StatusReport' = @(
+        'Hostname'
+        'SiteName'
+        @{Name = 'Status'; Expression = 'if ($_.Online) {"Online"} else {"Offline"}'}
+        @{Name = 'FQDN'; Expression = '"$($_.Hostname).$($_.Domain)"'}
+        'OperatingSystem'
+    )
+}
+```
+
+```powershell
+Get-RMMDevice | Export-RMMObjectCsv -Path .\StatusReport.csv -TransformName StatusReport
+```
+
+---
+
+## SEE ALSO
+
+- [Export-RMMObjectCsv](../commands/Export/Export-RMMObjectCsv.md)
+- [about_DattoRMM.Core](about_DattoRMM.Core.md)
+- [about_DattoRMM.CoreConfiguration](about_DattoRMM.CoreConfiguration.md)
+- [about_ClassIndex](./classes/about_ClassIndex.md)

--- a/docs/commands/about_CommandIndex.md
+++ b/docs/commands/about_CommandIndex.md
@@ -11,6 +11,7 @@ A reference index of all public functions in the DattoRMM.Core module, organised
 - [Component](#component)
 - [Config](#config)
 - [Devices](#devices)
+- [Export](#export)
 - [Filter](#filter)
 - [Jobs](#jobs)
 - [Sites](#sites)
@@ -78,6 +79,14 @@ A reference index of all public functions in the DattoRMM.Core module, organised
 | [`Move-RMMDevice`](Devices/Move-RMMDevice.md) | Moves a device from one site to another site. |
 | [`Set-RMMDeviceUDF`](Devices/Set-RMMDeviceUDF.md) | Sets user-defined fields on a device in Datto RMM. |
 | [`Set-RMMDeviceWarranty`](Devices/Set-RMMDeviceWarranty.md) | Sets the warranty expiration date on a device in Datto RMM. |
+
+## Export
+
+| Command | Synopsis |
+| ------- | -------- |
+| [`Export-RMMObjectCsv`](Export/Export-RMMObjectCsv.md) | Exports DattoRMM.Core objects to a flattened CSV file using named transforms. |
+
+See [about_DattoRMM.CoreExport](../about/about_DattoRMM.CoreExport.md) for details on transform authoring and custom transforms.
 
 ## Filter
 


### PR DESCRIPTION
## Overview
Introduces `Export-RMMObjectCsv`, a new command for exporting DattoRMM.Core objects (Sites, Devices, Alerts) to flattened CSV using named, user-extensible column transforms.

## Motivation
Users frequently need to export Sites, Devices, or Alerts to CSV for reporting and analysis. This command eliminates the need for manual property flattening and provides a consistent, predictable output format aligned with PowerShell patterns.

## Changes

### Public API
- **`Export-RMMObjectCsv`** — Exports typed objects to flattened CSV with automatic type detection, streaming output (constant memory), and dynamic tab-completable transform names. Supports Path-based, Method-based, and Expression-based column definitions.

### Transform System
- **Built-in transforms** — Provided for DRMMSite, DRMMDevice, DRMMAlert (Default and Summary each)
- **User-custom transforms** — Loaded from `$HOME/.DattoRMM.Core/ExportTransforms.psd1` and merged at module import
- **Any-class support** — Transform system works for any DRMMObject subclass
- **Column definition modes:**
  - `Path` — dot-notation for nested property access (e.g., `DevicesStatus.NumberOfDevices`)
  - `Method` — parameterless method calls (e.g., `GetSummary()`)
  - `Expression` — restricted expressions (member access, comparisons, conditionals)

### Security
- **Layered expression validation** (`Test-ExportExpression`)
  - Layer 1: Length cap (500 characters)
  - Layer 2: ASCII character whitelist
  - Layer 3: PowerShell AST parsing with whitelisted node types only
  - Layer 4: Variable restriction ($_, $null, $true, $false only)
- **Blocked constructs** — Cmdlet calls, .NET type access, arbitrary variables, assignments, redirections

### Implementation Details
- **Private/Data/ExportTransforms.psd1** — Built-in column transforms for three core types
- **Private/Export/Initialize-ExportTransforms.ps1** — Loads and merges transforms at module startup
- **Private/Export/ConvertTo-ExportProperty.ps1** — Converts psd1 entries to Select-Object properties
- **Private/Export/Test-ExportExpression.ps1** — AST-based expression validation
- **Module updates** — Manifest (43 functions), loader (Initialize-ExportTransforms call)

### Documentation
- **New** `about_DattoRMM.CoreExport.md` — Comprehensive guide with transform authoring, security model, and 8 examples
- **Updated** README.md, about_DattoRMM.Core.md, about_CommandIndex.md

## Key Features
- ✅ Streaming to disk (memory-safe for Azure Automation)
- ✅ Type auto-detection
- ✅ Dynamic, tab-completable transform names
- ✅ Optional timestamp and UDF columns
- ✅ User-extensible transforms (any class)
- ✅ Security-first validation
- ✅ Append support with schema consistency

## Issues
Fixes #11 

## Example Usage

```powershell
# Export all devices using Summary transform
Get-RMMDevice | Export-RMMObjectCsv -Path .\Devices.csv -TransformName Summary

# Export alerts with timestamp
Get-RMMAlert -Status All | Export-RMMObjectCsv -Path .\Alerts.csv -IncludeTimestamp

# Export devices with all UDF columns
Get-RMMDevice | Export-RMMObjectCsv -Path .\Devices.csv -IncludeUdf

# Using a custom user-defined transform
Get-RMMDevice | Export-RMMObjectCsv -Path .\Custom.csv -TransformName 'MyComplianceView'