### PR TITLE
feat: Add `-LegacyThrottle` switch to `Connect-DattoRMM`

### DIFF
--- a/DattoRMM.Core/DattoRMM.Core.psm1
+++ b/DattoRMM.Core/DattoRMM.Core.psm1
@@ -41,6 +41,9 @@ $Script:ApiMethodRetry = Import-PowerShellDataFile -Path "$PSScriptRoot\Private\
 # Initialize script-scoped auth object
 $Script:RMMAuth = $null
 
+# Legacy single-bucket throttle mode flag (set by Connect-DattoRMM -LegacyThrottle)
+$Script:LegacyThrottleMode = $false
+
 # Dot-source remaining .ps1 files in Private folder
 Get-ChildItem -Path $PSScriptRoot\Private -Filter *.ps1 -Recurse | Where-Object {$_.BaseName -ne 'howtothrottle'} | ForEach-Object {
 
@@ -103,6 +106,7 @@ $MyInvocation.MyCommand.ScriptBlock.Module.OnRemove = {
     }
     
     # Remove throttle state and module defaults
+    Remove-Variable -Name LegacyThrottleMode -Scope Script -ErrorAction SilentlyContinue
     Remove-Variable -Name RMMThrottle -Scope Script -ErrorAction SilentlyContinue
     Remove-Variable -Name ApiMethodRetry -Scope Script -ErrorAction SilentlyContinue
     Remove-Variable -Name ThrottleProfileDefaults -Scope Script -ErrorAction SilentlyContinue

--- a/DattoRMM.Core/Private/Throttle/Add-ThrottleRequest.ps1
+++ b/DattoRMM.Core/Private/Throttle/Add-ThrottleRequest.ps1
@@ -26,7 +26,7 @@ function Add-ThrottleRequest {
 
     $Now = [datetime]::UtcNow
 
-    if ($Method -eq 'Get') {
+    if ($Script:LegacyThrottleMode -or $Method -eq 'Get') {
 
         # Record in read bucket
         $Script:RMMThrottle.ReadLocalTimestamps.Add($Now)

--- a/DattoRMM.Core/Private/Throttle/Invoke-ApiThrottle.ps1
+++ b/DattoRMM.Core/Private/Throttle/Invoke-ApiThrottle.ps1
@@ -33,7 +33,7 @@ function Invoke-ApiThrottle {
         $OperationName
     )
 
-    $IsRead = ($Method -eq 'Get')
+    $IsRead = ($Script:LegacyThrottleMode -or $Method -eq 'Get')
     $Now = [datetime]::UtcNow
     $WindowStart = $Now.AddSeconds(-$Script:RMMThrottle.WindowSizeSeconds)
 

--- a/DattoRMM.Core/Public/Auth/Connect-DattoRMM.ps1
+++ b/DattoRMM.Core/Public/Auth/Connect-DattoRMM.ps1
@@ -54,6 +54,17 @@ function Connect-DattoRMM {
         
         To set a persistent default platform: Save-RMMConfig -DefaultPlatform Merlot
 
+    .PARAMETER LegacyThrottle
+        Forces the throttle engine to operate in legacy single-bucket mode. When enabled, all API
+        requests (including writes) are tracked against the read bucket only. Write-specific counters,
+        per-operation buckets, and write decay logic are bypassed.
+
+        Use this switch if your Datto RMM account uses the legacy single-bucket rate-limit model.
+        Default behaviour (modern multi-bucket model) is unchanged when this switch is not specified.
+
+        This is a temporary compatibility mechanism. It will be deprecated once automatic detection
+        of the rate-limit model is implemented.
+
     .PARAMETER Proxy
         Specifies a proxy server for the request, rather than connecting directly to the Datto RMM API.
         Enter the URI of a network proxy server. This parameter is optional and only needed if your
@@ -196,6 +207,9 @@ function Connect-DattoRMM {
         [RMMPlatform]
         $Platform,
 
+        [switch]
+        $LegacyThrottle,
+
         [Parameter(
             Mandatory = $false
         )]
@@ -337,6 +351,15 @@ function Connect-DattoRMM {
 
             }
         }
+    }
+
+    # Store legacy throttle mode flag
+    $Script:LegacyThrottleMode = $LegacyThrottle.IsPresent
+
+    if ($Script:LegacyThrottleMode) {
+
+        Write-Verbose "Legacy single-bucket throttle mode enabled. All requests will be tracked against the read bucket."
+
     }
 
     # Discover rate limits and initialise multi-bucket throttle state

--- a/DattoRMM.Core/Public/Auth/Disconnect-DattoRMM.ps1
+++ b/DattoRMM.Core/Public/Auth/Disconnect-DattoRMM.ps1
@@ -49,6 +49,7 @@ function Disconnect-DattoRMM {
     $Script:APIUrl = $null
     $Script:API = $null
     $Script:PageSize = $null
+    $Script:LegacyThrottleMode = $false
 
     Write-Verbose "Disconnected from Datto RMM API."
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 A PowerShell module for the Datto RMM API v2. Provides typed, object-oriented access to devices, sites, alerts, jobs, filters, variables, and account management with built-in adaptive throttling and secure credential handling.
 
-> **⚠️ Known Compatibility Issue**
+> **⚠️ Legacy Rate-Limit Compatibility**
 > 
-> Some Datto RMM accounts use a legacy single-bucket rate-limit model. **This module is incompatible with that configuration** and will not operate correctly if your account uses it. See [Known Issues](#known-issues) for details and workarounds. Support for both models is planned for `v0.6.0-beta.1`.
+> Some Datto RMM accounts use a legacy single-bucket rate-limit model. Use the `-LegacyThrottle` switch on `Connect-DattoRMM` to enable compatibility. See [Known Issues](#known-issues) for details.
 
 > **Requires PowerShell 7.4 or later** (Core edition only).
 
@@ -122,9 +122,17 @@ The following known issue is currently being tracked. Additional items may be ad
 
 ### Legacy Single‑Bucket Rate‑Limit Model (Platform Configuration)
 
-Some Datto RMM accounts are currently configured to use the legacy single‑bucket rate‑limit model. The module requires the newer read/write/operation rate‑limit model and cannot operate correctly when the legacy model is active.
+Some Datto RMM accounts are configured to use the legacy single‑bucket rate‑limit model instead of the modern read/write/operation model.
 
-Support for both models is planned for `v0.6.0‑beta.1`.
+To connect with legacy compatibility:
+
+```powershell
+Connect-DattoRMM -Key "your-api-key" -Secret $Secret -LegacyThrottle
+```
+
+When `-LegacyThrottle` is enabled, all API requests (including writes) are tracked against the read bucket only. Write-specific counters, per-operation buckets, and write decay logic are bypassed.
+
+This is a temporary compatibility mechanism. It will be deprecated once automatic detection of the rate-limit model is implemented.
 
 See Issue [#7 Issue: Add Support for Legacy Single‑Bucket Rate‑Limit Model (Module Currently Incompatible)](https://github.com/TheShadowTek/DattoRMM.Core/issues/7#issue-4204729279) for details and progress.
 

--- a/docs/about/about_DattoRMM.CoreThrottling.md
+++ b/docs/about/about_DattoRMM.CoreThrottling.md
@@ -159,3 +159,25 @@ Settings are stored at: `$HOME/.DattoRMM.Core/config.json`
 - The pause threshold defaults to the platform cutoff minus a configurable safety overhead
 - All profile settings can be adjusted at runtime without reconnecting
 - For best results across concurrent sessions, use the same profile on all active sessions targeting the same account
+
+## LEGACY SINGLE-BUCKET MODE
+
+Some Datto RMM accounts use a legacy rate-limit model with a single shared bucket instead of the modern read/write/operation model. If your account uses the legacy model, the default multi-bucket throttle engine will misclassify requests.
+
+To enable legacy compatibility, use the `-LegacyThrottle` switch when connecting:
+
+```powershell
+Connect-DattoRMM -Key "your-api-key" -Secret $Secret -LegacyThrottle
+```
+
+When enabled:
+
+- All API requests (including PUT, POST, DELETE) are tracked against the **read bucket only**
+- Write-specific counters, per-operation buckets, and write decay logic are bypassed
+- A single shared bucket is used for all rate-limit calculations
+- A diagnostic message is emitted confirming legacy mode is active
+
+Default behaviour (modern multi-bucket model) is unchanged when `-LegacyThrottle` is not specified.
+
+> [!NOTE]
+> This is a temporary compatibility mechanism. It will be deprecated once automatic detection of the rate-limit model is implemented. See Issue [#7](https://github.com/TheShadowTek/DattoRMM.Core/issues/7) and Issue [#33](https://github.com/TheShadowTek/DattoRMM.Core/issues/33) for details.


### PR DESCRIPTION
## Description
Adds `-LegacyThrottle` switch parameter to `Connect-DattoRMM` to enable compatibility with legacy single-bucket rate limiting tenants.

## Changes
- Adds `-LegacyThrottle` switch parameter to `Connect-DattoRMM` and stores `$Script:LegacyThrottleMode`
- Forces pre-request throttle gating and post-request recording to treat all HTTP methods as reads when enabled
  - `Private/Throttle/Invoke-ApiThrottle.ps1`
  - `Private/Throttle/Add-ThrottleRequest.ps1`
- Initializes and cleans up the script-scoped flag in:
  - `DattoRMM.Core.psm1`
  - `Public/Auth/Disconnect-DattoRMM.ps1`
- Updated documentation:
  - `README.md`
  - `docs/about/about_DattoRMM.CoreThrottling.md`

## Testing Notes
Default behaviour is unchanged when switch is not used.

**Follow-up testing required:**
- Manual validation against a legacy single-bucket tenant (if available) to confirm compatibility
- Add unit tests covering:
  - Bucket updates and recording (reads vs writes) with and without `-LegacyThrottle`
  - Decay and sliding-window behaviour under legacy mode
  - Concurrency and per-operation bucket bypassing
  - Request classification and calibration timing
- Run integration checks for pagination, token refresh, and retry/error paths to ensure no regressions