### PR TITLE
Feature/Throttle engine overhaul — unified multipliers, flat calibration floor, per-op write scaling, and stability-adaptive interval extension

### DIFF
--- a/.github/agents/throttle-analyst.agent.md
+++ b/.github/agents/throttle-analyst.agent.md
@@ -1,0 +1,174 @@
+---
+description: "Use when: analysing throttle diagnostic run data, inspecting or improving the Power BI semantic model (PBIP/TMDL), generating DAX measures or visuals, reasoning over utilisation/throughput/event datasets, comparing throttle profiles or concurrency levels, producing tuning or regression recommendations, or modifying the Throttle Diagnostic v2 semantic model schema."
+name: "Throttle Analyst"
+tools: [read, edit, search, todo]
+---
+
+You are an analytical engineering agent specialising in the DattoRMM.Core Throttle Diagnostic v2 dataset and its Power BI semantic model. You reason over the six CSV tables, the TMDL semantic model, and the PBIP report definition to produce diagnostic insights, DAX measures, and modelling recommendations.
+
+You do not write module code — that is the Throttle Engineer agent's domain. Your domain is the data that module produces.
+
+Respect all rules in `.github/copilot-instructions.md` at all times.
+
+---
+
+## Dataset Schema
+
+The six tables and their grains:
+
+| Table | Grain | Primary Keys |
+|---|---|---|
+| `metadata` | One row per run | `RunId` |
+| `expressions` | One row per expression per run | `ExprKey` (`RunId + ExpressionName`) |
+| `workers` | One row per worker per run | `WorkerId`, `ExprKey` |
+| `samples` | One row per sample period per bucket per run | `RunId`, `SamplePeriodIndex`, `BucketType`, `BucketName` |
+| `events` | One row per throttle debug event per worker | `RunId`, `ExprKey`, `WorkerId`, `Iteration`, `EventType` |
+| `throughput` | One row per expression per sample period per run | `RunId`, `ExprKey`, `SamplePeriodIndex` |
+
+### Key Columns by Table
+
+**metadata**: `RunId`, `TestName`, `Platform`, `DefaultThrottleProfile`, `ThrottleProfiles`, `ConcurrentSessions`, `ExpressionCount`, `TotalWorkers`, `StaggerDelaySeconds`, `SampleSeconds`, `BaselineSeconds`, `TestEndUtc`, `TotalDurationSeconds`, `TotalSamples`, `TotalEvents`, `ResultNotes`
+
+**expressions**: `RunId`, `ExpressionName`, `ExpressionIndex`, `ThrottleProfile`, `WorkersPerExpression`, `Expression`, `TotalIterations`, `AvgIterationMs`, `TotalErrors`, `ExprKey`
+
+**workers**: `RunId`, `ExpressionName`, `WorkerId`, `WorkerNumber`, `ThrottleProfile`, `StartUtc`, `EndUtc`, `DurationSeconds`, `TotalIterations`, `ExprKey`
+
+**samples**: `RunId`, `SamplePeriodIndex`, `SampleUtc`, `PeriodStartSec`, `PeriodEndSec`, `ElapsedSeconds`, `Phase`, `BucketType` (`Read`/`Write`/`Operation`), `BucketName`, `ApiCount`, `Limit`, `Remaining`
+
+**events**: `RunId`, `ExpressionName`, `WorkerId`, `WorkerNumber`, `ThrottleProfile`, `EventUtc`, `ElapsedSeconds`, `SamplePeriodIndex`, `Phase`, `Iteration`, `EventType`, `Track`, `ExprKey`
+
+**throughput**: `RunId`, `ExpressionName`, `ThrottleProfile`, `SamplePeriodIndex`, `SampleUtc`, `ElapsedSeconds`, `Phase`, `Iterations`, `IterationDelta`, `IterationsPerMinute`, `ExprKey`
+
+### Active Relationships
+
+```
+expressions.RunId        → metadata.RunId       (active)
+samples.RunId            → metadata.RunId       (active)
+workers.ExprKey          → expressions.ExprKey  (active)
+events.ExprKey           → expressions.ExprKey  (active)
+throughput.ExprKey       → expressions.ExprKey  (active)
+workers.RunId            → metadata.RunId       (inactive — use USERELATIONSHIP)
+throughput.RunId         → metadata.RunId       (inactive — use USERELATIONSHIP)
+events.RunId             → metadata.RunId       (inactive — use USERELATIONSHIP)
+```
+
+### Semantic Model Location
+- TMDL definitions: `Issues/ThrottleTests/DattoRMM.Core Workflow Analysis.SemanticModel/definition/tables/`
+- Relationships: `Issues/ThrottleTests/DattoRMM.Core Workflow Analysis.SemanticModel/definition/relationships.tmdl`
+- DAX queries: `Issues/ThrottleTests/DattoRMM.Core Workflow Analysis.SemanticModel/DAXQueries/`
+- Report pages: `Issues/ThrottleTests/DattoRMM.Core Workflow Analysis.Report/definition/pages/`
+- Raw CSVs: `Issues/ThrottleTests/ThrottleTuning_v3/`
+
+---
+
+## Analytical Workflows
+
+### Tuning Workflow
+When asked to analyse a run or compare runs:
+1. Establish baseline (T01-style single-session read, or write equivalent)
+2. Compare concurrent runs at the same profile — identify IPM change, utilisation change, event density increase
+3. Compare profiles at the same concurrency — isolate DelayMultiplier and threshold effects
+4. Identify the operating envelope: max IPM before pause events appear, utilisation band at steady state
+5. Diagnose imbalance: workers within the same expression should show similar iteration counts and AvgIterationMs
+
+Key signals:
+- `IterationsPerMinute` dropping over time → delay increasing or pause occurring
+- `EventType = 'Pause'` rows in events → hard cutoff reached
+- `EventType = 'Delay'` density increasing → approaching threshold
+- `ApiCount / Limit` in samples approaching 1.0 → quota pressure
+- `Remaining` near zero for a `BucketName` → near cutoff on that specific bucket
+- Worker `TotalIterations` spread wide → concurrency imbalance
+
+### Regression Workflow
+When comparing a new run against a baseline:
+1. Compare `IterationsPerMinute` at equivalent `ElapsedSeconds` points
+2. Compare `Pause` event count per run
+3. Compare peak `ApiCount / Limit` per bucket
+4. Flag any new `BucketName` appearing in samples that wasn't in the baseline
+5. State whether throughput, quota headroom, and stability improved or degraded
+
+---
+
+## DAX Guidelines
+
+When generating measures:
+- Use readable `VAR` names — never single-letter variables
+- Avoid repeating sub-expressions — extract to `VAR`
+- Add a one-line comment above each measure explaining intent
+- Use `ALLSELECTED` when the measure should respect slicers
+- Use `CALCULATE` + `USERELATIONSHIP` for inactive relationships
+- Never suggest bidirectional relationships — fan-out and ambiguity risks are documented in the model
+- Prefer `DIVIDE(numerator, denominator, 0)` over `/` to handle zero denominators
+- Keep measure names PascalCase: `[AvgIterationsPerMinute]`, `[PauseEventCount]`
+
+Example skeleton for a throughput measure:
+
+```dax
+// Average IPM across selected expressions and sample periods, Active phase only
+AvgIPM_Active =
+VAR ActiveRows =
+    FILTER(
+        throughput,
+        throughput[Phase] = "Active"
+    )
+RETURN
+    AVERAGEX(ActiveRows, throughput[IterationsPerMinute])
+```
+
+---
+
+## Visual Recommendations
+
+When proposing a visual, always provide:
+- **Visual type**
+- **Axis / X**: field and table
+- **Values / Y**: measure(s)
+- **Legend / Series**: field
+- **Filters/slicers**: required context
+- **Interpretation**: what to look for
+
+---
+
+## Modelling Recommendations
+
+When proposing schema changes:
+- State which table and column is being added or changed
+- Justify it against a specific analytical gap
+- Provide the TMDL column block if adding a column
+- Identify any cardinality or grain implications
+- Note if a relationship needs updating
+
+When proposing a bridge table:
+- Define its grain explicitly
+- List all columns with data types
+- Show the two relationships it resolves
+- Confirm it eliminates the many-to-many without introducing fan-out
+
+---
+
+## Output Format
+
+**Analysis output** — always structured as:
+1. Observed symptoms (from data, with column/table references)
+2. Likely root cause
+3. Supporting evidence (which fields, which values)
+4. Recommended next test or model change
+5. Recommended profile or concurrency adjustment (if applicable)
+
+**DAX output** — always: measure name, intent comment, DAX block, brief explanation of logic
+
+**Visual output** — always: the field/measure table above, then interpretation notes
+
+**Schema change output** — always: what changes, why, TMDL snippet or relationship delta
+
+---
+
+## Constraints
+
+- DO NOT invent columns that are not in the TMDL definitions above
+- DO NOT break grain — samples are per-bucket per period; do not aggregate across BucketType without explicit intent
+- DO NOT suggest bidirectional relationships
+- DO NOT modify the `cache.abf` file — it is a binary Power BI cache artifact
+- DO NOT edit the `StaticResources/` folder — those are theme files, not model files
+- DO NOT propose changes to module code (`Private/Throttle/*.ps1`) — defer to the Throttle Engineer agent
+- When uncertain about a column's values or a run's context, ask for the relevant CSV snippet or TMDL section before proceeding

--- a/.github/agents/throttle-engineer.agent.md
+++ b/.github/agents/throttle-engineer.agent.md
@@ -1,0 +1,91 @@
+---
+description: "Use when: debugging throttle behaviour, analysing debug output, identifying throttle bugs, explaining throttle controls or calibration mechanics, reviewing throttle profile values, suggesting throttle improvements, updating throttle documentation, or writing throttle-related commit messages. Throttle specialist for DattoRMM.Core rate-limit engine."
+name: "Throttle Engineer"
+tools: [read, edit, search, todo, execute]
+---
+
+You are a specialist in the DattoRMM.Core throttle engine. You have deep knowledge of the multi-bucket rate-limit system, its calibration logic, delay mechanics, and profile configuration.
+
+Respect all rules in `.github/copilot-instructions.md` and `.github/SKILL.md` at all times — formatting, naming conventions, commit message style, and documentation requirements all apply without exception.
+
+## Throttle Domain Knowledge
+
+### Files You Own
+- `DattoRMM.Core/Private/Throttle/Invoke-ApiThrottle.ps1` — pre-request gate; calibration interval; delay evaluation
+- `DattoRMM.Core/Private/Throttle/Update-Throttle.ps1` — API calibration; sets ReadDelayMS/WriteDelayMS/Utilisation
+- `DattoRMM.Core/Private/Throttle/Add-ThrottleRequest.ps1` — records timestamps only; does NOT set utilisation fields
+- `DattoRMM.Core/Private/Throttle/Set-ThrottleDefaults.ps1` — initial state; all runtime fields defined here
+- `DattoRMM.Core/Private/Throttle/Initialize-ThrottleState.ps1` — post-connect init from live API
+- `DattoRMM.Core/Private/Throttle/Invoke-ThrottleBucketPrune.ps1` — prunes expired window timestamps
+- `DattoRMM.Core/Private/Data/ThrottleProfiles.psd1` — profile presets (Cautious, Medium, Aggressive, DefaultProfile)
+- `docs/about/about_DattoRMM.CoreThrottling.md` — primary user-facing throttle documentation
+- `DattoRMM.Core/en-US/about_DattoRMM.CoreThrottling.help.txt` — compiled help (build artifact; regenerated from docs)
+
+### Architectural Invariants
+- `ReadUtilisation` and `WriteUtilisation` are **API-calibrated fields**, written only by `Update-Throttle`. Never by `Add-ThrottleRequest` or any other caller.
+- Local utilisation ratios are **always derived at evaluation time** from timestamp list counts, never stored separately.
+- `DriftGap = Abs(StoredUtil - LocalUtil)` — this is the primary signal for concurrent session detection. If `StoredUtil` is wrong, drift detection is blind.
+- The flat calibration floor (`$MaxDelay = $Script:RMMThrottle.ReadDelayMS`) is held until the next calibration fires. There is no decay.
+- `EffectiveInterval` governs both the calibration trigger and is the denominator of any floor timing reasoning.
+- Read and write tracks are fully independent: separate timestamps, limits, utilisation, delay, calibration state.
+- Per-operation write delays are scaled by `LimitRatio = Max(1.0, AccountWriteLimit / OperationLimit)`.
+
+### Key Profile Parameters
+| Parameter | Role |
+|---|---|
+| `DelayMultiplier` | ms of delay per unit of utilisation — primary throughput control |
+| `ThrottleUtilisationThreshold` | utilisation at which delays begin |
+| `ThrottleCutOffOverhead` | safety margin below `accountCutOffRatio` before pause triggers |
+| `CalibrationBaseSeconds` | ceiling calibration interval at full confidence, zero drift |
+| `CalibrationMinSeconds` | absolute floor — prevents calibration API spam |
+| `CalibrationConfidenceCount` | samples needed before interval reaches full base |
+| `DriftThresholdPercent` | drift gap at which interval compression begins |
+| `DriftScalingFactor` | how aggressively interval compresses beyond threshold |
+
+## Debugging
+
+When given debug output (Write-Debug log lines), always:
+1. Read the relevant source files before analysing — never reason from memory alone.
+2. Identify the track (Read/Write), utilisation values (API vs Local), drift gap, delay applied, calibration trigger.
+3. Distinguish between cold-start behaviour (first ~10 requests, no state) and steady-state behaviour.
+4. Check whether `ReadUtilisation` / `WriteUtilisation` show the API-reported value or have been overwritten by local counts — this is the most common source of bugs.
+5. State your diagnosis explicitly before suggesting a fix.
+
+## Suggesting Improvements
+
+- Prefer the fewest possible moving parts. Reduce configurable parameters where the same behaviour can be derived from existing ones.
+- Explain the trade-offs of any suggested change (throughput, safety margin, cold-start behaviour, concurrent session impact).
+- Never introduce new profile parameters without justifying why an existing parameter cannot be reused.
+- For changes that affect calibration timing, delay magnitude, or pause thresholds, state the impact across all three profiles.
+
+## Documentation
+
+When throttle code changes, check and update:
+1. `docs/about/about_DattoRMM.CoreThrottling.md` — Delay Behaviour, Concurrent Use, and any affected section
+2. `.DESCRIPTION` and inline comments in the changed `.ps1` file(s)
+3. Note that `en-US/about_DattoRMM.CoreThrottling.help.txt` is a build artifact — flag it for regeneration, do not edit directly.
+
+## Commit Messages
+
+When asked to create a commit, follow the repository convention exactly:
+
+```
+<type>: <imperative title> (<version-tag>)
+
+<optional summary line>
+
+- <file or area>: <what changed and why>
+- <file or area>: <what changed and why>
+```
+
+Types: `fix:` `refactor:` `feat:` `docs:` `build:` `chore:`
+
+Be specific: name the functions and files changed, state the root cause for fixes, describe the before/after for behaviour changes.
+
+## Constraints
+
+- DO NOT modify `DattoRMM.Core.psd1` version numbers unless the user explicitly asks for a version bump.
+- DO NOT change public API function signatures (`Connect-DattoRMM`, `Set-RMMConfig`, etc.) — throttle is private infrastructure.
+- DO NOT introduce new `$Script:RMMThrottle` state fields without checking `Set-ThrottleDefaults.ps1` and `Initialize-ThrottleState.ps1` — both must be updated together.
+- DO NOT edit `en-US/about_DattoRMM.CoreThrottling.help.txt` directly — it is a build artifact.
+- DO NOT run destructive git commands (`reset --hard`, `push --force`, branch deletion) without explicit user confirmation.

--- a/DattoRMM.Core/DattoRMM.Core.psd1
+++ b/DattoRMM.Core/DattoRMM.Core.psd1
@@ -8,7 +8,7 @@
 RootModule = 'DattoRMM.Core.psm1'
 
 # Version number of this module. 
-ModuleVersion = '0.5.52'
+ModuleVersion = '0.5.53'
 
 # Supported PSEditions
 CompatiblePSEditions = @('Core')

--- a/DattoRMM.Core/Private/Classes/DRMMThrottleStatus/DRMMThrottleStatus.psm1
+++ b/DattoRMM.Core/Private/Classes/DRMMThrottleStatus/DRMMThrottleStatus.psm1
@@ -96,10 +96,8 @@ class DRMMThrottleStatus : DRMMObject {
     [double]$ReadDelayMs
     # The current computed delay in milliseconds for write (POST/PUT/DELETE) requests. When throttling is active, this value increases proportionally with write utilisation to slow request rates.
     [double]$WriteDelayMs
-    # The configured multiplier (e.g., 750) used to calculate delay from read utilisation: ReadDelayMs = ReadUtilisation * DelayMultiplier.
+    # The configured multiplier (e.g., 500) used to calculate delay from utilisation: DelayMs = Utilisation * DelayMultiplier. Applied to both read and write tracks.
     [double]$DelayMultiplier
-    # The configured multiplier (e.g., 1000) used to calculate delay from write utilisation: WriteDelayMs = WriteUtilisation * WriteDelayMultiplier.
-    [double]$WriteDelayMultiplier
     # The UTC datetime of the last read-track throttle calibration, when local read state was synchronized with API-reported values.
     [Nullable[datetime]]$ReadLastCalibrationUtc
     # The UTC datetime of the last write-track throttle calibration, when local write state was synchronized with API-reported values.

--- a/DattoRMM.Core/Private/Data/ThrottleProfiles.psd1
+++ b/DattoRMM.Core/Private/Data/ThrottleProfiles.psd1
@@ -49,9 +49,9 @@
     }
     'Aggressive' = @{
         DelayMultiplier = 250
-        CalibrationBaseSeconds = 15
-        CalibrationMinSeconds = 1
-        CalibrationConfidenceCount = 80
+        CalibrationBaseSeconds = 5
+        CalibrationMinSeconds = 0.5
+        CalibrationConfidenceCount = 40
         DriftThresholdPercent = 0.02
         DriftScalingFactor = 1.5
         ThrottleUtilisationThreshold = 0.45

--- a/DattoRMM.Core/Private/Data/ThrottleProfiles.psd1
+++ b/DattoRMM.Core/Private/Data/ThrottleProfiles.psd1
@@ -21,25 +21,23 @@
 #   DriftFactor      = 1 / (1 + (DriftGap / DriftThreshold) * DriftScaling)
 #   Interval         = Max(Min, Base * ConfidenceFactor * DriftFactor)
 #
-# WriteDelayMultiplier: delay multiplier applied to write bucket pressure (separate from global read/write DelayMultiplier).
 # UnknownOperationSafetyFactor: fractional delay applied to write operations with no explicit operation mapping.
 # Note: Profiles tuned for up to 5 concurrent heavy-use sessions sharing the same API quota.
 
 @{
     'Cautious' = @{
-        DelayMultiplier = 1500
+        DelayMultiplier = 1000
         CalibrationBaseSeconds = 5
         CalibrationMinSeconds = 0.5
         CalibrationConfidenceCount = 30
         DriftThresholdPercent = 0.01
         DriftScalingFactor = 3
-        ThrottleUtilisationThreshold = 0.15
-        ThrottleCutOffOverhead = 0.10
-        WriteDelayMultiplier = 1750
+        ThrottleUtilisationThreshold = 0.2
+        ThrottleCutOffOverhead = 0.08
         UnknownOperationSafetyFactor = 0.5
     }
     'Medium' = @{
-        DelayMultiplier = 750
+        DelayMultiplier = 500
         CalibrationBaseSeconds = 8
         CalibrationMinSeconds = 0.5
         CalibrationConfidenceCount = 50
@@ -47,23 +45,21 @@
         DriftScalingFactor = 2
         ThrottleUtilisationThreshold = 0.3
         ThrottleCutOffOverhead = 0.05
-        WriteDelayMultiplier = 1000
         UnknownOperationSafetyFactor = 0.3
     }
     'Aggressive' = @{
-        DelayMultiplier = 300
+        DelayMultiplier = 250
         CalibrationBaseSeconds = 15
         CalibrationMinSeconds = 1
         CalibrationConfidenceCount = 80
         DriftThresholdPercent = 0.02
         DriftScalingFactor = 1.5
-        ThrottleUtilisationThreshold = 0.5
+        ThrottleUtilisationThreshold = 0.45
         ThrottleCutOffOverhead = 0.04
-        WriteDelayMultiplier = 750
-        UnknownOperationSafetyFactor = 0.1
+        UnknownOperationSafetyFactor = 0.15
     }
     'DefaultProfile' = @{
-        DelayMultiplier = 750
+        DelayMultiplier = 500
         CalibrationBaseSeconds = 8
         CalibrationMinSeconds = 0.5
         CalibrationConfidenceCount = 50
@@ -71,7 +67,6 @@
         DriftScalingFactor = 2
         ThrottleUtilisationThreshold = 0.3
         ThrottleCutOffOverhead = 0.05
-        WriteDelayMultiplier = 1000
         UnknownOperationSafetyFactor = 0.3
     }
 }

--- a/DattoRMM.Core/Private/Data/ThrottleProfiles.psd1
+++ b/DattoRMM.Core/Private/Data/ThrottleProfiles.psd1
@@ -30,43 +30,43 @@
         CalibrationBaseSeconds = 5
         CalibrationMinSeconds = 0.5
         CalibrationConfidenceCount = 30
-        DriftThresholdPercent = 0.01
+        DriftThresholdPercent = 0.015
         DriftScalingFactor = 3
         ThrottleUtilisationThreshold = 0.2
         ThrottleCutOffOverhead = 0.08
         UnknownOperationSafetyFactor = 0.5
     }
     'Medium' = @{
-        DelayMultiplier = 700
+        DelayMultiplier = 750
         CalibrationBaseSeconds = 6
         CalibrationMinSeconds = 0.7
         CalibrationConfidenceCount = 50
         DriftThresholdPercent = 0.02
         DriftScalingFactor = 2
-        ThrottleUtilisationThreshold = 0.3
-        ThrottleCutOffOverhead = 0.05
+        ThrottleUtilisationThreshold = 0.27
+        ThrottleCutOffOverhead = 0.07
         UnknownOperationSafetyFactor = 0.3
     }
     'Aggressive' = @{
-        DelayMultiplier = 500
+        DelayMultiplier = 400
         CalibrationBaseSeconds = 5
         CalibrationMinSeconds = 0.5
-        CalibrationConfidenceCount = 40
+        CalibrationConfidenceCount = 35
         DriftThresholdPercent = 0.02
         DriftScalingFactor = 1.5
-        ThrottleUtilisationThreshold = 0.45
-        ThrottleCutOffOverhead = 0.04
+        ThrottleUtilisationThreshold = 0.50
+        ThrottleCutOffOverhead = 0.05
         UnknownOperationSafetyFactor = 0.15
     }
     'DefaultProfile' = @{
-        DelayMultiplier = 700
+        DelayMultiplier = 750
         CalibrationBaseSeconds = 6
         CalibrationMinSeconds = 0.7
         CalibrationConfidenceCount = 50
         DriftThresholdPercent = 0.02
         DriftScalingFactor = 2
-        ThrottleUtilisationThreshold = 0.3
-        ThrottleCutOffOverhead = 0.05
+        ThrottleUtilisationThreshold = 0.27
+        ThrottleCutOffOverhead = 0.07
         UnknownOperationSafetyFactor = 0.3
     }
 }

--- a/DattoRMM.Core/Private/Data/ThrottleProfiles.psd1
+++ b/DattoRMM.Core/Private/Data/ThrottleProfiles.psd1
@@ -22,7 +22,7 @@
 #   Interval         = Max(Min, Base * ConfidenceFactor * DriftFactor)
 #
 # UnknownOperationSafetyFactor: fractional delay applied to write operations with no explicit operation mapping.
-# Note: Profiles tuned for up to 5 concurrent heavy-use sessions sharing the same API quota.
+# Note: Profiles tuned for up to 4 concurrent heavy-use sessions sharing the same API quota.
 
 @{
     'Cautious' = @{
@@ -37,9 +37,9 @@
         UnknownOperationSafetyFactor = 0.5
     }
     'Medium' = @{
-        DelayMultiplier = 500
-        CalibrationBaseSeconds = 8
-        CalibrationMinSeconds = 0.5
+        DelayMultiplier = 700
+        CalibrationBaseSeconds = 6
+        CalibrationMinSeconds = 0.7
         CalibrationConfidenceCount = 50
         DriftThresholdPercent = 0.02
         DriftScalingFactor = 2
@@ -48,7 +48,7 @@
         UnknownOperationSafetyFactor = 0.3
     }
     'Aggressive' = @{
-        DelayMultiplier = 250
+        DelayMultiplier = 500
         CalibrationBaseSeconds = 5
         CalibrationMinSeconds = 0.5
         CalibrationConfidenceCount = 40
@@ -59,9 +59,9 @@
         UnknownOperationSafetyFactor = 0.15
     }
     'DefaultProfile' = @{
-        DelayMultiplier = 500
-        CalibrationBaseSeconds = 8
-        CalibrationMinSeconds = 0.5
+        DelayMultiplier = 700
+        CalibrationBaseSeconds = 6
+        CalibrationMinSeconds = 0.7
         CalibrationConfidenceCount = 50
         DriftThresholdPercent = 0.02
         DriftScalingFactor = 2

--- a/DattoRMM.Core/Private/Data/ThrottleProfiles.psd1
+++ b/DattoRMM.Core/Private/Data/ThrottleProfiles.psd1
@@ -21,6 +21,13 @@
 #   DriftFactor      = 1 / (1 + (DriftGap / DriftThreshold) * DriftScaling)
 #   Interval         = Max(Min, Base * ConfidenceFactor * DriftFactor)
 #
+# Stability-adaptive calibration: once a session reaches full confidence and accumulates
+# CalibrationStabilityThreshold consecutive stable calibrations (no drift, no delays, below
+# threshold), the effective base is allowed to double, capped at CalibrationMaxSeconds.
+# Any instability signal (drift, delay onset, utilisation spike) resets the count immediately.
+# This reduces calibration API call overhead in long-running single-session reporting extracts
+# without sacrificing responsiveness to concurrent-session drift.
+#
 # UnknownOperationSafetyFactor: fractional delay applied to write operations with no explicit operation mapping.
 # Note: Profiles tuned for up to 4 concurrent heavy-use sessions sharing the same API quota.
 
@@ -30,7 +37,9 @@
         CalibrationBaseSeconds = 5
         CalibrationMinSeconds = 0.5
         CalibrationConfidenceCount = 30
-        DriftThresholdPercent = 0.015
+        CalibrationMaxSeconds = 30
+        CalibrationStabilityThreshold = 3
+        DriftThresholdPercent = 0.02
         DriftScalingFactor = 3
         ThrottleUtilisationThreshold = 0.2
         ThrottleCutOffOverhead = 0.08
@@ -41,9 +50,11 @@
         CalibrationBaseSeconds = 6
         CalibrationMinSeconds = 0.7
         CalibrationConfidenceCount = 50
+        CalibrationMaxSeconds = 20
+        CalibrationStabilityThreshold = 4
         DriftThresholdPercent = 0.02
         DriftScalingFactor = 2
-        ThrottleUtilisationThreshold = 0.27
+        ThrottleUtilisationThreshold = 0.30
         ThrottleCutOffOverhead = 0.07
         UnknownOperationSafetyFactor = 0.3
     }
@@ -52,6 +63,8 @@
         CalibrationBaseSeconds = 5
         CalibrationMinSeconds = 0.5
         CalibrationConfidenceCount = 35
+        CalibrationMaxSeconds = 10
+        CalibrationStabilityThreshold = 5
         DriftThresholdPercent = 0.02
         DriftScalingFactor = 1.5
         ThrottleUtilisationThreshold = 0.50
@@ -63,9 +76,11 @@
         CalibrationBaseSeconds = 6
         CalibrationMinSeconds = 0.7
         CalibrationConfidenceCount = 50
+        CalibrationMaxSeconds = 20
+        CalibrationStabilityThreshold = 4
         DriftThresholdPercent = 0.02
         DriftScalingFactor = 2
-        ThrottleUtilisationThreshold = 0.27
+        ThrottleUtilisationThreshold = 0.30
         ThrottleCutOffOverhead = 0.07
         UnknownOperationSafetyFactor = 0.3
     }

--- a/DattoRMM.Core/Private/Throttle/Add-ThrottleRequest.ps1
+++ b/DattoRMM.Core/Private/Throttle/Add-ThrottleRequest.ps1
@@ -11,7 +11,8 @@
     the global write bucket and the per-operation write bucket (if the operation is tracked).
     Reads and writes are independent quotas — a read never touches the write bucket and a
     write never touches the read bucket. This function is called after each API response to
-    maintain accurate local utilisation estimates between calibration cycles.
+    record the timestamp only. Local utilisation ratios are derived from these timestamps at
+    evaluation time. API-calibrated utilisation fields are owned exclusively by Update-Throttle.
 #>
 function Add-ThrottleRequest {
     [CmdletBinding()]
@@ -31,16 +32,10 @@ function Add-ThrottleRequest {
         # Record in read bucket
         $Script:RMMThrottle.ReadLocalTimestamps.Add($Now)
 
-        # Update local read utilisation estimate
-        $Script:RMMThrottle.ReadUtilisation = $Script:RMMThrottle.ReadLocalTimestamps.Count / [math]::Max($Script:RMMThrottle.ReadLimit, 1)
-
     } else {
 
         # Record in global write bucket
         $Script:RMMThrottle.WriteLocalTimestamps.Add($Now)
-
-        # Update local write utilisation estimate
-        $Script:RMMThrottle.WriteUtilisation = $Script:RMMThrottle.WriteLocalTimestamps.Count / [math]::Max($Script:RMMThrottle.WriteLimit, 1)
 
         # Per-operation write bucket
         if ($OperationName -and $Script:RMMThrottle.OperationBuckets.ContainsKey($OperationName)) {

--- a/DattoRMM.Core/Private/Throttle/Initialize-ThrottleState.ps1
+++ b/DattoRMM.Core/Private/Throttle/Initialize-ThrottleState.ps1
@@ -92,6 +92,10 @@ function Initialize-ThrottleState {
                         $Script:RMMThrottle.OperationBuckets[$OpName].LocalTimestamps.Add($WindowStart.AddTicks($OpSeedStep.Ticks * $i))
 
                     }
+
+                    # Seed API-reported utilisation so the per-op floor is available before the first Update-Throttle fires
+                    $Script:RMMThrottle.OperationBuckets[$OpName].ApiUtilisation = $OpCount / [math]::Max([int]$_.Value.limit, 1)
+
                 }
             }
         }

--- a/DattoRMM.Core/Private/Throttle/Invoke-ApiThrottle.ps1
+++ b/DattoRMM.Core/Private/Throttle/Invoke-ApiThrottle.ps1
@@ -180,18 +180,10 @@ function Invoke-ApiThrottle {
     if ($IsRead) {
 
         # Read requests: evaluate read bucket only
-        # Seed MaxDelay with a decaying floor from the last calibration-determined value.
-        # This carries the API-reported picture forward between calibrations, preventing
-        # sessions with low local sample counts from being undercharged when other concurrent
-        # sessions are consuming shared quota. The floor decays linearly to zero over one
-        # calibration base interval, so late in the interval local pressure alone governs.
-        if ($Script:RMMThrottle.ReadDelayMS -gt 0) {
-
-            $CalibElapsed = ($Now - $Script:RMMThrottle.ReadLastCalibrationUtc).TotalSeconds
-            $DecayFactor = [math]::Max(0.0, 1.0 - ($CalibElapsed / [math]::Max($Script:RMMThrottle.CalibrationBaseSeconds, 1)))
-            $MaxDelay = $Script:RMMThrottle.ReadDelayMS * $DecayFactor
-
-        }
+        # Seed MaxDelay with the calibration-determined floor and hold it flat until next
+        # calibration. This prevents undercharging when local sample counts are low and
+        # other concurrent sessions are consuming shared quota.
+        $MaxDelay = $Script:RMMThrottle.ReadDelayMS
 
         if ($EffectiveUtil -ge $PauseThreshold) {
 
@@ -209,15 +201,8 @@ function Invoke-ApiThrottle {
     } else {
 
         # Write requests: evaluate global write bucket + per-operation bucket
-        # Seed MaxDelay with a decaying floor from the last calibration-determined value.
-        # Decays linearly to zero over one calibration base interval.
-        if ($Script:RMMThrottle.WriteDelayMS -gt 0) {
-
-            $CalibElapsed = ($Now - $Script:RMMThrottle.WriteLastCalibrationUtc).TotalSeconds
-            $DecayFactor = [math]::Max(0.0, 1.0 - ($CalibElapsed / [math]::Max($Script:RMMThrottle.CalibrationBaseSeconds, 1)))
-            $MaxDelay = $Script:RMMThrottle.WriteDelayMS * $DecayFactor
-
-        }
+        # Seed MaxDelay with the calibration-determined floor and hold it flat until next calibration.
+        $MaxDelay = $Script:RMMThrottle.WriteDelayMS
 
         # Global write bucket
         if ($Script:RMMThrottle.WriteLimit -gt 0) {

--- a/DattoRMM.Core/Private/Throttle/Invoke-ApiThrottle.ps1
+++ b/DattoRMM.Core/Private/Throttle/Invoke-ApiThrottle.ps1
@@ -239,10 +239,17 @@ function Invoke-ApiThrottle {
         }
 
         # Per-operation write bucket (if operation is tracked)
+        # Delay is scaled by the ratio of account write limit to operation limit so that
+        # low-limit operations (e.g. 100) get proportionally larger delays than high-limit
+        # ones (e.g. 600). This prevents small-bucket operations from racing toward pause
+        # because each request consumes a much larger fraction of a small bucket.
+        # The ratio is derived from live API-reported limits, so it self-tunes if Datto
+        # adjusts operation limits in future.
         if ($OperationName -and $Script:RMMThrottle.OperationBuckets.ContainsKey($OperationName)) {
 
             $OpBucket = $Script:RMMThrottle.OperationBuckets[$OperationName]
             $OpUtil = $OpBucket.LocalTimestamps.Count / [math]::Max($OpBucket.Limit, 1)
+            $LimitRatio = [math]::Max(1.0, $Script:RMMThrottle.WriteLimit / [math]::Max($OpBucket.Limit, 1))
 
             if ($OpUtil -ge $PauseThreshold) {
 
@@ -257,7 +264,7 @@ function Invoke-ApiThrottle {
 
             } elseif ($OpUtil -ge $Script:RMMThrottle.ThrottleUtilisationThreshold) {
 
-                $Delay = $OpUtil * $Script:RMMThrottle.DelayMultiplier
+                $Delay = $OpUtil * $Script:RMMThrottle.DelayMultiplier * $LimitRatio
                 $MaxDelay = [math]::Max($MaxDelay, $Delay)
 
             }
@@ -290,8 +297,8 @@ function Invoke-ApiThrottle {
             Write-Warning "High API utilisation detected ($PauseBucketLabel $([math]::Round($PauseBucketUtil * 100, 2))%). Pausing requests to avoid rate limiting."
             $WarningPreference = $SavedWarningPreference
 
-            Write-Debug "Throttle[$TrackLabel]: Pause triggered by '$PauseBucketLabel' at $([math]::Round($PauseBucketUtil * 100, 2))% (threshold $([math]::Round($PauseThreshold * 100, 2))%). Sleeping 60s."
-            Start-Sleep -Seconds 60
+            Write-Debug "Throttle[$TrackLabel]: Pause triggered by '$PauseBucketLabel' at $([math]::Round($PauseBucketUtil * 100, 2))% (threshold $([math]::Round($PauseThreshold * 100, 2))%). Sleeping 30s."
+            Start-Sleep -Seconds 30
             Write-Debug "Throttle[$TrackLabel]: Pause sleep completed. Re-evaluating all applicable buckets."
             Update-Throttle
 

--- a/DattoRMM.Core/Private/Throttle/Invoke-ApiThrottle.ps1
+++ b/DattoRMM.Core/Private/Throttle/Invoke-ApiThrottle.ps1
@@ -180,13 +180,16 @@ function Invoke-ApiThrottle {
     if ($IsRead) {
 
         # Read requests: evaluate read bucket only
-        # Seed MaxDelay with the last calibration-determined value as a floor.
-        # This carries the API-reported picture forward between calibrations,
-        # preventing sessions with low local sample counts from being undercharged
-        # when other concurrent sessions are consuming shared quota.
+        # Seed MaxDelay with a decaying floor from the last calibration-determined value.
+        # This carries the API-reported picture forward between calibrations, preventing
+        # sessions with low local sample counts from being undercharged when other concurrent
+        # sessions are consuming shared quota. The floor decays linearly to zero over one
+        # calibration base interval, so late in the interval local pressure alone governs.
         if ($Script:RMMThrottle.ReadDelayMS -gt 0) {
 
-            $MaxDelay = $Script:RMMThrottle.ReadDelayMS
+            $CalibElapsed = ($Now - $Script:RMMThrottle.ReadLastCalibrationUtc).TotalSeconds
+            $DecayFactor = [math]::Max(0.0, 1.0 - ($CalibElapsed / [math]::Max($Script:RMMThrottle.CalibrationBaseSeconds, 1)))
+            $MaxDelay = $Script:RMMThrottle.ReadDelayMS * $DecayFactor
 
         }
 
@@ -206,10 +209,13 @@ function Invoke-ApiThrottle {
     } else {
 
         # Write requests: evaluate global write bucket + per-operation bucket
-        # Seed MaxDelay from calibration-determined write delay floor
+        # Seed MaxDelay with a decaying floor from the last calibration-determined value.
+        # Decays linearly to zero over one calibration base interval.
         if ($Script:RMMThrottle.WriteDelayMS -gt 0) {
 
-            $MaxDelay = $Script:RMMThrottle.WriteDelayMS
+            $CalibElapsed = ($Now - $Script:RMMThrottle.WriteLastCalibrationUtc).TotalSeconds
+            $DecayFactor = [math]::Max(0.0, 1.0 - ($CalibElapsed / [math]::Max($Script:RMMThrottle.CalibrationBaseSeconds, 1)))
+            $MaxDelay = $Script:RMMThrottle.WriteDelayMS * $DecayFactor
 
         }
 
@@ -226,7 +232,7 @@ function Invoke-ApiThrottle {
 
             } elseif ($WriteUtil -ge $Script:RMMThrottle.ThrottleUtilisationThreshold) {
 
-                $Delay = $WriteUtil * $Script:RMMThrottle.WriteDelayMultiplier
+                $Delay = $WriteUtil * $Script:RMMThrottle.DelayMultiplier
                 $MaxDelay = [math]::Max($MaxDelay, $Delay)
 
             }
@@ -251,7 +257,7 @@ function Invoke-ApiThrottle {
 
             } elseif ($OpUtil -ge $Script:RMMThrottle.ThrottleUtilisationThreshold) {
 
-                $Delay = $OpUtil * $Script:RMMThrottle.WriteDelayMultiplier
+                $Delay = $OpUtil * $Script:RMMThrottle.DelayMultiplier
                 $MaxDelay = [math]::Max($MaxDelay, $Delay)
 
             }
@@ -259,7 +265,7 @@ function Invoke-ApiThrottle {
         } elseif ($OperationName) {
 
             # Unknown write operation — apply conservative safety delay
-            $SafetyDelay = $Script:RMMThrottle.UnknownOperationSafetyFactor * $Script:RMMThrottle.WriteDelayMultiplier
+            $SafetyDelay = $Script:RMMThrottle.UnknownOperationSafetyFactor * $Script:RMMThrottle.DelayMultiplier
 
             if ($SafetyDelay -gt 0) {
 

--- a/DattoRMM.Core/Private/Throttle/Invoke-ApiThrottle.ps1
+++ b/DattoRMM.Core/Private/Throttle/Invoke-ApiThrottle.ps1
@@ -110,17 +110,43 @@ function Invoke-ApiThrottle {
     # DelayMS 0 × 10 = 0 → no effect, confidence/drift formula governs.
     $DelayPacingFloorSeconds = ($CurrentDelayMS / 1000) * 10
 
+    # Stability-adaptive base: when a session has been stable (no drift, no delays, below
+    # threshold) for CalibrationStabilityThreshold consecutive calibrations, the effective
+    # base is allowed to double per threshold block, capped at CalibrationMaxSeconds.
+    # This reduces calibration API call overhead in long-running stable single-session
+    # extracts without sacrificing responsiveness — any instability signal resets the count
+    # immediately and the interval returns to CalibrationBaseSeconds on the next calibration.
+    $StableCount = if ($IsRead) {$Script:RMMThrottle.ReadStableCalibrationCount} else {$Script:RMMThrottle.WriteStableCalibrationCount}
+    $StabilityDoublings = [math]::Floor($StableCount / [math]::Max($Script:RMMThrottle.CalibrationStabilityThreshold, 1))
+    $ExtendedBaseSeconds = [math]::Min(
+        $Script:RMMThrottle.CalibrationMaxSeconds,
+        $Script:RMMThrottle.CalibrationBaseSeconds * [math]::Pow(2, $StabilityDoublings)
+    )
+
+    # Stability-adaptive base: when a session has been stable (no drift, no delays, below
+    # threshold) for CalibrationStabilityThreshold consecutive calibrations, the effective
+    # base is allowed to double per threshold block, capped at CalibrationMaxSeconds.
+    # This reduces calibration API call overhead in long-running stable single-session
+    # extracts without sacrificing responsiveness — any instability signal resets the count
+    # immediately and the interval returns to CalibrationBaseSeconds on the next calibration.
+    $StableCount = if ($IsRead) {$Script:RMMThrottle.ReadStableCalibrationCount} else {$Script:RMMThrottle.WriteStableCalibrationCount}
+    $StabilityDoublings = [math]::Floor($StableCount / [math]::Max($Script:RMMThrottle.CalibrationStabilityThreshold, 1))
+    $ExtendedBaseSeconds = [math]::Min(
+        $Script:RMMThrottle.CalibrationMaxSeconds,
+        $Script:RMMThrottle.CalibrationBaseSeconds * [math]::Pow(2, $StabilityDoublings)
+    )
+
     # Effective interval: highest of three floors:
     #   1. CalibrationMinSeconds: absolute floor to prevent API spam
-    #   2. Base × Confidence × DriftFactor: dynamic formula
+    #   2. ExtendedBase × Confidence × DriftFactor: dynamic formula using stability-adaptive base
     #   3. DelayPacingFloor: delay-correlated floor when throttling is active
     # Low confidence OR high drift → short interval → frequent calibration
-    # High confidence AND low drift → full base → minimal API overhead
+    # High confidence AND low drift AND stable → extended base → minimal API overhead
     # High delay → long interval → let paced requests breathe between calibrations
     $EffectiveInterval = [math]::Max(
         $Script:RMMThrottle.CalibrationMinSeconds,
         [math]::Max(
-            $Script:RMMThrottle.CalibrationBaseSeconds * $ConfidenceFactor * $DriftFactor,
+            $ExtendedBaseSeconds * $ConfidenceFactor * $DriftFactor,
             $DelayPacingFloorSeconds
         )
     )
@@ -175,6 +201,25 @@ function Invoke-ApiThrottle {
             $EffectiveUtil = [math]::Max($Script:RMMThrottle.WriteUtilisation, $LocalUtil)
 
         }
+
+        # Stability count: increment if this calibration was clean (no drift, no delays, below
+        # threshold); reset to 0 on any instability so the extended interval snaps back to base.
+        $CalibrationWasStable = (
+            $DriftGap -lt $Script:RMMThrottle.DriftThresholdPercent -and
+            $CurrentDelayMS -eq 0 -and
+            $EffectiveUtil -lt $Script:RMMThrottle.ThrottleUtilisationThreshold
+        )
+
+        if ($IsRead) {
+
+            $Script:RMMThrottle.ReadStableCalibrationCount = if ($CalibrationWasStable) {$Script:RMMThrottle.ReadStableCalibrationCount + 1} else {0}
+
+        } else {
+
+            $Script:RMMThrottle.WriteStableCalibrationCount = if ($CalibrationWasStable) {$Script:RMMThrottle.WriteStableCalibrationCount + 1} else {0}
+
+        }
+
     }
 
     # --- Calculate max delay across all applicable buckets for this request type ---

--- a/DattoRMM.Core/Private/Throttle/Invoke-ApiThrottle.ps1
+++ b/DattoRMM.Core/Private/Throttle/Invoke-ApiThrottle.ps1
@@ -89,7 +89,19 @@ function Invoke-ApiThrottle {
 
     }
 
-    $DriftFactor = 1 / (1 + $DriftRatio * $Script:RMMThrottle.DriftScalingFactor)
+    # Drift guard: when no delays are active and utilisation is below threshold, drift is
+    # rolling-window oscillation (API window phase vs local window phase desynchronising
+    # naturally), not a concurrent-session signal. Suppress compression so single-session
+    # calibration intervals stay stable rather than collapsing to CalibrationMinSeconds.
+    if ($CurrentDelayMS -eq 0 -and $EffectiveUtil -lt $Script:RMMThrottle.ThrottleUtilisationThreshold) {
+
+        $DriftFactor = 1.0
+
+    } else {
+
+        $DriftFactor = 1 / (1 + $DriftRatio * $Script:RMMThrottle.DriftScalingFactor)
+
+    }
 
     # Delay-pacing floor: when delays are active, scale calibration interval so that
     # enough requests pass between calibrations to avoid wasting API calls on
@@ -232,8 +244,9 @@ function Invoke-ApiThrottle {
         # adjusts operation limits in future.
         if ($OperationName -and $Script:RMMThrottle.OperationBuckets.ContainsKey($OperationName)) {
 
-            $OpBucket = $Script:RMMThrottle.OperationBuckets[$OperationName]
-            $OpUtil = $OpBucket.LocalTimestamps.Count / [math]::Max($OpBucket.Limit, 1)
+            $OpBucket   = $Script:RMMThrottle.OperationBuckets[$OperationName]
+            $ApiOpUtil  = if ($OpBucket.ContainsKey('ApiUtilisation')) { $OpBucket.ApiUtilisation } else { 0.0 }
+            $OpUtil     = [math]::Max($ApiOpUtil, $OpBucket.LocalTimestamps.Count / [math]::Max($OpBucket.Limit, 1))
             $LimitRatio = [math]::Max(1.0, $Script:RMMThrottle.WriteLimit / [math]::Max($OpBucket.Limit, 1))
 
             if ($OpUtil -ge $PauseThreshold) {
@@ -323,8 +336,9 @@ function Invoke-ApiThrottle {
                 # Per-operation write bucket
                 if ($OperationName -and $Script:RMMThrottle.OperationBuckets.ContainsKey($OperationName)) {
 
-                    $OpBucket = $Script:RMMThrottle.OperationBuckets[$OperationName]
-                    $OpUtil = $OpBucket.LocalTimestamps.Count / [math]::Max($OpBucket.Limit, 1)
+                    $OpBucket  = $Script:RMMThrottle.OperationBuckets[$OperationName]
+                    $ApiOpUtil = if ($OpBucket.ContainsKey('ApiUtilisation')) { $OpBucket.ApiUtilisation } else { 0.0 }
+                    $OpUtil    = [math]::Max($ApiOpUtil, $OpBucket.LocalTimestamps.Count / [math]::Max($OpBucket.Limit, 1))
 
                     if ($OpUtil -ge $PauseThreshold) {
 

--- a/DattoRMM.Core/Private/Throttle/Set-ThrottleDefaults.ps1
+++ b/DattoRMM.Core/Private/Throttle/Set-ThrottleDefaults.ps1
@@ -34,7 +34,7 @@ function Set-ThrottleDefaults {
 
     $Script:RMMThrottle = [ordered]@{
         Profile = 'DefaultProfile'                                                      # Active throttle profile name
-        DelayMultiplier = 750                                                           # Delay multiplier for read bucket throttling
+        DelayMultiplier = 500                                                           # Delay multiplier for all bucket throttling (read and write)
         ThrottleCutOffOverhead = 0.05                                                   # Safety margin below accountCutOffRatio for pause trigger
         ThrottleUtilisationThreshold = 0.3                                              # Utilisation ratio at which throttling activates
         CalibrationBaseSeconds = 8                                                      # Ceiling interval at high confidence and zero drift
@@ -42,7 +42,6 @@ function Set-ThrottleDefaults {
         CalibrationConfidenceCount = 50                                                 # Local samples needed before interval reaches full base
         DriftThresholdPercent = 0.02                                                    # Drift gap at which accelerated calibration begins (2%)
         DriftScalingFactor = 2                                                          # How aggressively interval shrinks as drift exceeds threshold
-        WriteDelayMultiplier = 1000                                                     # Delay multiplier for write bucket throttling
         UnknownOperationSafetyFactor = 0.3                                              # Fractional delay for unmapped write operations
         WindowSizeSeconds = 60                                                          # Rolling window size (discovered from API)
         ReadLimit = 600                                                                 # Read (GET) rate limit (discovered from API as accountRateLimit)

--- a/DattoRMM.Core/Private/Throttle/Set-ThrottleDefaults.ps1
+++ b/DattoRMM.Core/Private/Throttle/Set-ThrottleDefaults.ps1
@@ -40,6 +40,8 @@ function Set-ThrottleDefaults {
         CalibrationBaseSeconds = 8                                                      # Ceiling interval at high confidence and zero drift
         CalibrationMinSeconds = 0.5                                                     # Absolute floor to prevent excessive API calibration calls
         CalibrationConfidenceCount = 50                                                 # Local samples needed before interval reaches full base
+        CalibrationMaxSeconds = 20                                                      # Ceiling for stability-extended calibration interval
+        CalibrationStabilityThreshold = 4                                               # Consecutive stable calibrations before interval begins extending
         DriftThresholdPercent = 0.02                                                    # Drift gap at which accelerated calibration begins (2%)
         DriftScalingFactor = 2                                                          # How aggressively interval shrinks as drift exceeds threshold
         UnknownOperationSafetyFactor = 0.3                                              # Fractional delay for unmapped write operations
@@ -54,6 +56,8 @@ function Set-ThrottleDefaults {
         WriteLastCalibrationUtc = [datetime]::MinValue                                  # Pre-connect safe default; overwritten by Initialize-ThrottleState on connect
         ReadSamplesAtLastCalibration = 0                                                # Local read sample count at last calibration (for request gate)
         WriteSamplesAtLastCalibration = 0                                               # Local write sample count at last calibration (for request gate)
+        ReadStableCalibrationCount = 0                                                  # Consecutive stable read calibrations since last instability reset
+        WriteStableCalibrationCount = 0                                                 # Consecutive stable write calibrations since last instability reset
         ReadUtilisation = 0.0                                                           # Computed read utilisation (accountCount / accountRateLimit)
         WriteUtilisation = 0.0                                                          # Computed write utilisation (accountWriteCount / accountWriteRateLimit)
         ReadDelayMS = 0                                                                 # Current computed read delay in milliseconds

--- a/DattoRMM.Core/Private/Throttle/Update-Throttle.ps1
+++ b/DattoRMM.Core/Private/Throttle/Update-Throttle.ps1
@@ -112,7 +112,7 @@ function Update-Throttle {
 
     if ($WriteThrottle) {
 
-        $Script:RMMThrottle.WriteDelayMS = $Script:RMMThrottle.WriteUtilisation * $Script:RMMThrottle.WriteDelayMultiplier
+        $Script:RMMThrottle.WriteDelayMS = $Script:RMMThrottle.WriteUtilisation * $Script:RMMThrottle.DelayMultiplier
 
     } else {
 

--- a/DattoRMM.Core/Private/Throttle/Update-Throttle.ps1
+++ b/DattoRMM.Core/Private/Throttle/Update-Throttle.ps1
@@ -70,12 +70,15 @@ function Update-Throttle {
 
         $RateInfo.operationWriteStatus.PSObject.Properties | ForEach-Object {
 
-            $OpName = $_.Name
+            $OpName    = $_.Name
+            $ApiOpCount = [math]::Max(0, [int]$_.Value.count)
+            $ApiOpUtil  = $ApiOpCount / [math]::Max([int]$_.Value.limit, 1)
 
             if ($Script:RMMThrottle.OperationBuckets.ContainsKey($OpName)) {
 
-                # Update limit in case it changed dynamically
-                $Script:RMMThrottle.OperationBuckets[$OpName].Limit = $_.Value.limit
+                # Update limit and API-reported utilisation in case either changed dynamically
+                $Script:RMMThrottle.OperationBuckets[$OpName].Limit          = $_.Value.limit
+                $Script:RMMThrottle.OperationBuckets[$OpName].ApiUtilisation = $ApiOpUtil
 
             } else {
 
@@ -83,6 +86,7 @@ function Update-Throttle {
                 $Script:RMMThrottle.OperationBuckets[$OpName] = @{
                     Limit           = $_.Value.limit
                     LocalTimestamps = [System.Collections.Generic.List[datetime]]::new()
+                    ApiUtilisation  = $ApiOpUtil
                 }
 
             }

--- a/DattoRMM.Core/Private/Throttle/howtothrottle.ps1
+++ b/DattoRMM.Core/Private/Throttle/howtothrottle.ps1
@@ -39,7 +39,6 @@ Manually set any of the following throttle values in your config JSON to overrid
     - DriftScalingFactor             : How aggressively interval shrinks with drift - default 2
     - ThrottleUtilisationThreshold   : Utilisation threshold to start delays - default 0.3
     - ThrottleCutOffOverhead         : Safety margin below pause threshold - default 0.05
-    - WriteDelayMultiplier           : Delay multiplier for write operations - default 1000
     - UnknownOperationSafetyFactor   : Fractional delay for unmapped writes - default 0.3
 
  Any of these keys present in your config file will override the corresponding module preset at startup.

--- a/DattoRMM.Core/Private/Throttle/howtothrottle.ps1
+++ b/DattoRMM.Core/Private/Throttle/howtothrottle.ps1
@@ -32,13 +32,15 @@ DO THIS AT YOUR OWN RISK.
 Manually set any of the following throttle values in your config JSON to override the module presets:
     - ThrottleProfile                : Set to "Custom" to enable custom values
     - DelayMultiplier                : Multiplier for delay calculation (in ms) - default 750
-    - CalibrationBaseSeconds         : Ceiling interval when confidence high and drift low - default 8
-    - CalibrationMinSeconds          : Absolute floor to prevent API spam - default 0.5
+    - CalibrationBaseSeconds         : Ceiling interval when confidence high and drift low - default 6
+    - CalibrationMinSeconds          : Absolute floor to prevent API spam - default 0.7
     - CalibrationConfidenceCount     : Samples required for full confidence - default 50
+    - CalibrationMaxSeconds          : Ceiling for stability-extended calibration interval - default 20
+    - CalibrationStabilityThreshold  : Consecutive stable calibrations before interval begins extending - default 4
     - DriftThresholdPercent          : Drift gap triggering accelerated calibration - default 0.02 (2%)
     - DriftScalingFactor             : How aggressively interval shrinks with drift - default 2
     - ThrottleUtilisationThreshold   : Utilisation threshold to start delays - default 0.3
-    - ThrottleCutOffOverhead         : Safety margin below pause threshold - default 0.05
+    - ThrottleCutOffOverhead         : Safety margin below pause threshold - default 0.07
     - UnknownOperationSafetyFactor   : Fractional delay for unmapped writes - default 0.3
 
  Any of these keys present in your config file will override the corresponding module preset at startup.

--- a/DattoRMM.Core/Public/Account/Get-RMMThrottleStatus.ps1
+++ b/DattoRMM.Core/Public/Account/Get-RMMThrottleStatus.ps1
@@ -77,8 +77,7 @@ function Get-RMMThrottleStatus {
         - Pause (bool): Whether hard pause is currently active
         - ReadDelayMs (double): Current computed read delay in milliseconds
         - WriteDelayMs (double): Current computed write delay in milliseconds
-        - DelayMultiplier (double): Configured read delay multiplier
-        - WriteDelayMultiplier (double): Configured write delay multiplier
+        - DelayMultiplier (double): Configured delay multiplier (used for both read and write)
         - ReadLastCalibrationUtc (datetime): UTC time of the last read calibration
         - WriteLastCalibrationUtc (datetime): UTC time of the last write calibration
         - ReadSamplesAtLastCalibration (int): Local read samples at last calibration
@@ -130,7 +129,6 @@ function Get-RMMThrottleStatus {
         $Result.ThrottleUtilisationThreshold = $Script:RMMThrottle.ThrottleUtilisationThreshold
         $Result.PauseThreshold = $RateInfo.accountCutOffRatio - $Script:RMMThrottle.ThrottleCutOffOverhead
         $Result.DelayMultiplier = $Script:RMMThrottle.DelayMultiplier
-        $Result.WriteDelayMultiplier = $Script:RMMThrottle.WriteDelayMultiplier
         $Result.ReadLastCalibrationUtc = $Script:RMMThrottle.ReadLastCalibrationUtc
         $Result.WriteLastCalibrationUtc = $Script:RMMThrottle.WriteLastCalibrationUtc
         $Result.ReadSamplesAtLastCalibration = $Script:RMMThrottle.ReadSamplesAtLastCalibration
@@ -171,7 +169,7 @@ function Get-RMMThrottleStatus {
 
         if ($WriteThrottle) {
 
-            $Result.WriteDelayMs = $Result.WriteUtilisation * $Script:RMMThrottle.WriteDelayMultiplier
+            $Result.WriteDelayMs = $Result.WriteUtilisation * $Script:RMMThrottle.DelayMultiplier
 
         } else {
 

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ To connect with legacy compatibility:
 Connect-DattoRMM -Key "your-api-key" -Secret $Secret -LegacyThrottle
 ```
 
-When `-LegacyThrottle` is enabled, all API requests (including writes) are tracked against the read bucket only. Write-specific counters, per-operation buckets, and write decay logic are bypassed.
+When `-LegacyThrottle` is enabled, all API requests (including writes) are tracked against the read bucket only. Write-specific counters and per-operation buckets are bypassed.
 
 This is a temporary compatibility mechanism. It will be deprecated once automatic detection of the rate-limit model is implemented.
 

--- a/docs/about/about_DattoRMM.CoreThrottling.md
+++ b/docs/about/about_DattoRMM.CoreThrottling.md
@@ -101,7 +101,7 @@ Together these mechanisms mean a session under sustained load self-regulates nat
 
 When utilisation crosses the configured threshold, a delay is applied before each request. The delay scales linearly with utilisation — higher utilisation produces a longer delay. The threshold and a single unified `DelayMultiplier` are controlled by the selected profile. Both reads and writes use the same multiplier.
 
-Read and write delays are computed independently against their respective buckets. Each track carries a **decaying calibration floor** forward between calibrations — the last calibration-determined delay decays linearly to zero over one calibration base interval. This prevents sessions with low local sample counts from being undercharged when concurrent sessions are consuming shared quota, while ensuring stale calibration data does not persist indefinitely.
+Read and write delays are computed independently against their respective buckets. Each track carries a **calibration floor** forward between calibrations — the last API-reported delay is held flat until the next calibration fires. This prevents sessions with low local sample counts from being undercharged when concurrent sessions are consuming shared quota. The floor is reset on every calibration, so it always reflects the most recent API-reported pressure.
 
 For write operations, the delay is calculated independently per applicable bucket (global write and per-operation), and the **highest value** across all write buckets governs the actual delay applied.
 
@@ -159,7 +159,7 @@ Save-RMMConfig
 
 ## CONCURRENT USE
 
-All sessions using the same Datto RMM account share the same read and write quotas. The throttling system detects pressure from other sessions through calibration drift — when API-reported utilisation exceeds what local tracking expects, the system tightens its calibration cadence. A decaying calibration floor carries the API-reported delay forward between calibrations, preventing undercharging when local sample counts are low. The floor decays linearly to zero over one calibration base interval, so stale data never persists. Read and write tracks detect drift independently.
+All sessions using the same Datto RMM account share the same read and write quotas. The throttling system detects pressure from other sessions through calibration drift — when API-reported utilisation exceeds what local tracking expects, the system tightens its calibration cadence. A flat calibration floor carries the API-reported delay forward between calibrations, preventing undercharging when local sample counts are low. The floor is held at the calibration-determined value and reset on each calibration. Read and write tracks detect drift independently.
 
 Recommended profiles by concurrency:
 

--- a/docs/about/about_DattoRMM.CoreThrottling.md
+++ b/docs/about/about_DattoRMM.CoreThrottling.md
@@ -23,33 +23,57 @@ A read request only counts against the read limit. A write request only counts a
 
 ### Architecture
 
-Every request passes through a pre-request gate that evaluates pressure against the appropriate bucket(s) based on the HTTP method. Read requests are evaluated against the read bucket only. Write requests are evaluated against write buckets only.
+Every API request flows through a layered pipeline. The throttle gate sits inside the retry engine, evaluating pressure against the appropriate bucket(s) based on HTTP method before each attempt.
 
 ```
-  ┌──────────────────────────────────┐
-  │         Incoming Request         │
-  └─────────────────┬────────────────┘
-                    │
-        ┌───────────▼────────────┐
-        │    Pre-Request Gate    │
-        │  (method-based routing)│
-        └──┬──────────┬──────────┘
-           │          │
-  GET only │          │ PUT/POST/DELETE only
-           │          │
-  ┌────────▼──┐  ┌────▼───────────────────────────────┐
-  │   Read    │  │         Write (non-GET only)       │
-  │  Bucket   │  ├──────────────┬─────────────────────┤
-  │ (GET req) │  │ Global Write │ Per-Operation (×16) │
-  └───────────┘  └──────┬───────┴──────────┬──────────┘
-                        │                  │
-                        └──────────────────┘
-                              │
-                    ┌─────────▼──────────┐
-                    │  Highest pressure  │
-                    │   → delay applied  │
-                    └────────────────────┘
+  ┌─────────────────────────────────────────────────────────────┐
+  │                  Public Function Layer                      │
+  │           (Get-RMMDevice, Set-RMMDeviceUdf, ...)            │
+  └──────────────────────────┬──────────────────────────────────┘
+                             │
+  ┌──────────────────────────▼──────────────────────────────────┐
+  │                     Invoke-ApiMethod                        │
+  │  • Proactive token refresh (5-min buffer before expiry)     │
+  │  • URI + header + body assembly                             │
+  │  • Operation classification (Resolve-ThrottleOperationName) │
+  │  • Pagination loop (follows nextPageUrl until exhausted)    │
+  └──────────────────────────┬──────────────────────────────────┘
+                             │  (per page / per request)
+  ┌──────────────────────────▼──────────────────────────────────┐
+  │                   Invoke-ApiRestMethod                      │
+  │  ┌───────────────── Retry Loop ──────────────────────┐      │
+  │  │                                                   │      │
+  │  │  1. Invoke-ApiThrottle ◄── PRE-REQUEST GATE       │      │
+  │  │  2. Invoke-RestMethod  ◄── HTTP call              │      │
+  │  │  3. Add-ThrottleRequest ◄── record in window      │      │
+  │  │                                                   │      │
+  │  │  On error: retry / token refresh / 429 handling   │      │
+  │  └───────────────────────────────────────────────────┘      │
+  └─────────────────────────────────────────────────────────────┘
+                             │
+  ┌──────────────────────────▼──────────────────────────────────┐
+  │                    Invoke-ApiThrottle                       │
+  │               (Pre-Request Throttle Gate)                   │
+  │                                                             │
+  │  • Route by HTTP method (GET vs PUT/POST/DELETE)            │
+  │  • Evaluate calibration interval (confidence + drift)       │
+  │  • Trigger Update-Throttle when interval expires            │
+  │  • Evaluate all applicable buckets:                         │
+  │                                                             │
+  │     GET only           PUT/POST/DELETE only                 │
+  │    ┌──────────┐       ┌──────────────────────────────────┐  │
+  │    │  Read    │       │        Write (non-GET only)      │  │
+  │    │  Bucket  │       ├──────────────┬───────────────────┤  │
+  │    │          │       │ Global Write │ Per-Operation     │  │
+  │    └──────────┘       └──────────────┴───────────────────┘  │
+  │                                                             │
+  │  • Highest pressure across all applicable buckets           │
+  │    → delay (scaled by utilisation × DelayMultiplier)        │
+  │    → or pause if any bucket exceeds hard cutoff             │
+  └─────────────────────────────────────────────────────────────┘
 ```
+
+The throttle gate and the retry engine are deliberately separate concerns. The gate paces requests; the retry engine handles transient failures and token refresh. On HTTP 429 (rate limit exceeded), the retry engine triggers a calibration via `Update-Throttle` and waits 120 seconds before retrying.
 
 ### Local Tracking and Calibration
 
@@ -63,34 +87,54 @@ Read and write tracks maintain **independent calibration state** (confidence, dr
 - A write-heavy session calibrates based on write pressure; reads benefit from the shared data.
 - If both tracks are active, whichever is under more pressure triggers calibration more frequently.
 
-Calibration frequency per track adapts based on:
-- How much local data has been collected (early in a session, calibrations are more frequent)
-- Whether the local and API-reported figures have drifted apart (indicating concurrent activity)
-- How much delay is already being applied (if the system is already pacing heavily, it backs off on calibration frequency to avoid unnecessary overhead)
+Calibration frequency per track adapts based on three competing floors (highest wins):
 
-This means a session under sustained load will self-regulate naturally — delays pace the requests, and calibration intervals extend proportionally so the system isn't spending API budget on calibration calls it doesn't need.
+1. **Absolute minimum** (`CalibrationMinSeconds`) — prevents API spam regardless of other factors.
+2. **Confidence × Drift formula** (`CalibrationBaseSeconds × ConfidenceFactor × DriftFactor`) — few local samples or high drift produce shorter intervals; full confidence and low drift produce the full base interval.
+3. **Delay-pacing floor** (`CurrentDelayMS × 10`) — when delays are active, the calibration interval scales proportionally so enough paced requests pass between calibrations.
+
+A **request-count gate** also triggers early calibration when enough requests have passed since the last calibration, even if the time interval has not elapsed. This ensures the system detects concurrent sessions early in the session lifecycle when confidence is still building.
+
+Together these mechanisms mean a session under sustained load self-regulates naturally — delays pace the requests, calibration intervals extend proportionally, and the system avoids wasting API budget on calibration calls it doesn't need.
 
 ### Delay Behaviour
 
-When utilisation crosses the configured threshold, a delay is applied before each request. The delay scales with utilisation — higher utilisation produces a longer delay. The threshold and delay multiplier are controlled by the selected profile.
+When utilisation crosses the configured threshold, a delay is applied before each request. The delay scales linearly with utilisation — higher utilisation produces a longer delay. The threshold and a single unified `DelayMultiplier` are controlled by the selected profile. Both reads and writes use the same multiplier.
 
-Read and write delays are computed independently. Each track carries its own calibration-determined delay floor forward between calibrations. For write operations, the delay is calculated independently per applicable bucket (global write and per-operation), and the highest value across all write buckets is used. Write operations are treated more conservatively than reads by default.
+Read and write delays are computed independently against their respective buckets. Each track carries a **decaying calibration floor** forward between calibrations — the last calibration-determined delay decays linearly to zero over one calibration base interval. This prevents sessions with low local sample counts from being undercharged when concurrent sessions are consuming shared quota, while ensuring stale calibration data does not persist indefinitely.
 
-If utilisation on either track reaches the hard cutoff threshold (configurable via the profile), requests of that type are paused entirely until utilisation drops. This is a last-resort protection mechanism and should rarely trigger under normal operation with an appropriate profile selected.
+For write operations, the delay is calculated independently per applicable bucket (global write and per-operation), and the **highest value** across all write buckets governs the actual delay applied.
+
+#### Per-Operation Limit-Ratio Scaling
+
+Per-operation write delays are scaled by the ratio of the account write limit to the operation's own limit. This ensures that low-limit operations (e.g. site-create at 100) receive proportionally larger delays than high-limit operations (e.g. device-udf at 600), preventing small buckets from racing toward pause.
+
+```
+LimitRatio = Max(1.0, AccountWriteLimit / OperationLimit)
+Delay      = OperationUtilisation × DelayMultiplier × LimitRatio
+```
+
+The ratio is derived from live API-reported limits, so it self-tunes if Datto adjusts operation limits in future.
+
+#### Pause Behaviour
+
+If utilisation on any applicable bucket reaches the hard cutoff threshold (platform cutoff minus a configurable safety overhead), requests of that type are paused entirely. The system sleeps for 30 seconds, recalibrates via `Update-Throttle`, and re-evaluates all applicable buckets. The pause loop continues until every relevant bucket drops below the threshold. This is a last-resort protection mechanism and should rarely trigger under normal operation with an appropriate profile selected.
 
 ## PROFILES
 
 Three built-in profiles are available, tuned for different concurrency levels:
 
-| Profile   | Best For                        | Delay Onset | Write Conservatism |
-|-----------|---------------------------------|-------------|--------------------|
-| Aggressive | Single session, high throughput | ~50%        | Moderate           |
-| Medium     | 2-3 concurrent sessions        | ~30%        | Balanced           |
-| Cautious   | 3-5 concurrent sessions        | ~15%        | High               |
+| Profile    | Best For                         | Delay Onset | DelayMultiplier | Calibration Base | Target Utilisation |
+|------------|----------------------------------|-------------|-----------------|------------------|--------------------|
+| Aggressive | Single session, high throughput  | ~45%        | 250             | 5s               | 60–70%             |
+| Medium     | 2–3 concurrent sessions          | ~30%        | 500             | 8s               | 70–80%             |
+| Cautious   | 3–5 concurrent sessions          | ~20%        | 1000            | 5s               | Below 60%          |
 
 The `Medium` profile is the default. It provides a reasonable balance for interactive and lightly automated use.
 
-Choose `Cautious` for long-running automation, scheduled tasks, or any scenario where multiple sessions may be active simultaneously. It introduces delays earlier and detects shared quota contention more aggressively, keeping overall utilisation well below the platform limit to leave headroom for other workloads.
+The `Aggressive` profile uses a shorter calibration base interval and lower confidence count, allowing it to react quickly to utilisation dips and win bandwidth in mixed-profile scenarios. Its lower `DelayMultiplier` produces shorter delays per percentage point of utilisation, pushing throughput higher.
+
+Choose `Cautious` for long-running automation, scheduled tasks, or any scenario where multiple sessions may be active simultaneously. It introduces delays earlier, uses a high `DelayMultiplier` for steeper delay curves, and detects shared quota contention more aggressively — keeping overall utilisation well below the platform limit to leave headroom for other workloads.
 
 ## CONFIGURATION
 
@@ -115,7 +159,7 @@ Save-RMMConfig
 
 ## CONCURRENT USE
 
-All sessions using the same Datto RMM account share the same read and write quotas. The throttling system detects pressure from other sessions through calibration drift — when API-reported utilisation exceeds what local tracking expects, the system tightens its calibration cadence and applies a delay floor to carry that pressure forward until the next calibration. Read and write tracks detect drift independently.
+All sessions using the same Datto RMM account share the same read and write quotas. The throttling system detects pressure from other sessions through calibration drift — when API-reported utilisation exceeds what local tracking expects, the system tightens its calibration cadence. A decaying calibration floor carries the API-reported delay forward between calibrations, preventing undercharging when local sample counts are low. The floor decays linearly to zero over one calibration base interval, so stale data never persists. Read and write tracks detect drift independently.
 
 Recommended profiles by concurrency:
 
@@ -155,8 +199,10 @@ Settings are stored at: `$HOME/.DattoRMM.Core/config.json`
 
 ## NOTES
 
-- Throttling operates entirely pre-request; it does not react to HTTP errors after the fact
+- The throttle gate operates pre-request, proactively pacing requests before they are sent
+- If a 429 does occur, the retry engine triggers a calibration and waits 120 seconds before retrying
 - The pause threshold defaults to the platform cutoff minus a configurable safety overhead
+- Pause sleep is 30 seconds per loop iteration, with recalibration after each sleep
 - All profile settings can be adjusted at runtime without reconnecting
 - For best results across concurrent sessions, use the same profile on all active sessions targeting the same account
 

--- a/docs/about/about_DattoRMM.CoreThrottling.md
+++ b/docs/about/about_DattoRMM.CoreThrottling.md
@@ -93,9 +93,7 @@ Calibration frequency per track adapts based on three competing floors (highest 
 2. **Confidence × Drift formula** (`CalibrationBaseSeconds × ConfidenceFactor × DriftFactor`) — few local samples or high drift produce shorter intervals; full confidence and low drift produce the full base interval.
 3. **Delay-pacing floor** (`CurrentDelayMS × 10`) — when delays are active, the calibration interval scales proportionally so enough paced requests pass between calibrations.
 
-A **request-count gate** also triggers early calibration when enough requests have passed since the last calibration, even if the time interval has not elapsed. This ensures the system detects concurrent sessions early in the session lifecycle when confidence is still building.
-
-Together these mechanisms mean a session under sustained load self-regulates naturally — delays pace the requests, calibration intervals extend proportionally, and the system avoids wasting API budget on calibration calls it doesn't need.
+In addition, the base interval used in floor 2 is **stability-adaptive**. Once a session has reached full confidence and accumulated `CalibrationStabilityThreshold` consecutive calibrations with no instability signal — no drift above threshold, no active delays, utilisation below onset threshold — the effective base doubles, capped at `CalibrationMaxSeconds`. Any instability signal (drift, delay onset, utilisation spike) resets the stable count immediately and the interval returns to `CalibrationBaseSeconds`. This reduces calibration API call overhead in long-running single-session reporting extracts without sacrificing responsiveness to concurrent-session signals.
 
 ### Delay Behaviour
 
@@ -124,11 +122,11 @@ If utilisation on any applicable bucket reaches the hard cutoff threshold (platf
 
 Three built-in profiles are available, tuned for different concurrency levels:
 
-| Profile    | Best For                         | Delay Onset | DelayMultiplier | Calibration Base | Target Utilisation |
-|------------|----------------------------------|-------------|-----------------|------------------|--------------------|
-| Aggressive | Single session, high throughput  | ~45%        | 250             | 5s               | 60–70%             |
-| Medium     | 2–3 concurrent sessions          | ~30%        | 500             | 8s               | 70–80%             |
-| Cautious   | 3–5 concurrent sessions          | ~20%        | 1000            | 5s               | Below 60%          |
+| Profile    | Best For                         | Delay Onset | DelayMultiplier | Calibration Base | Calibration Max |
+|------------|----------------------------------|-------------|-----------------|------------------|-----------------|
+| Aggressive | Single session, high throughput  | ~50%        | 400             | 5s               | 10s             |
+| Medium     | 2–3 concurrent sessions          | ~30%        | 750             | 6s               | 20s             |
+| Cautious   | 3–5 concurrent sessions          | ~20%        | 1000            | 5s               | 30s             |
 
 The `Medium` profile is the default. It provides a reasonable balance for interactive and lightly automated use.
 


### PR DESCRIPTION
### Summary

This branch refactors the DattoRMM.Core throttle engine across 6 commits, replacing the original ad-hoc delay model with a principled, profile-driven system. The changes progress in dependency order: unified multipliers first, then calibration floor mechanics, then per-operation write scaling, then the stability-adaptive interval extension that brings the whole system together.

All changes are private infrastructure. No public API surfaces were modified.

---

### Changes

#### Throttle engine (`Private/Throttle/`)

- **`Invoke-ApiThrottle.ps1`** — Unified Read and Write delay calculation under `DelayMultiplier`; replaced decaying calibration floor with a flat floor held until the next calibration fires; added stability-adaptive calibration interval extension (`ExtendedBaseSeconds = Min(CalibMax, CalibBase × 2^StabilityDoublings)`); fixed drift detection to correctly compare API-reported vs locally-derived utilisation
- **`Update-Throttle.ps1`** — `ReadUtilisation` / `WriteUtilisation` are now written exclusively here (API-calibrated values only); removed all stale overwrite paths that caused drift detection to be blind
- **`Add-ThrottleRequest.ps1`** — Constrained to recording timestamps only; no longer touches utilisation fields
- **`Set-ThrottleDefaults.ps1`** — Added `ReadStableCalibrationCount`, `WriteStableCalibrationCount`, `CalibrationMaxSeconds`, `CalibrationStabilityThreshold` to initial runtime state
- **`Initialize-ThrottleState.ps1`** — Updated to populate new state fields from live API on connect


#### Profile data (`Private/Data/`)

- **`ThrottleProfiles.psd1`** — Full retune across all three profiles following Rd2 analysis; added `CalibrationMaxSeconds` and `CalibrationStabilityThreshold` to all blocks; per-operation write delays now expressed via `LimitRatio` scaling

#### Classes

- **`DRMMThrottleStatus.psm1`** — Updated status class to surface new calibration state fields

#### Public API

- **`Get-RMMThrottleStatus.ps1`** — Minor update to reflect new state fields in output

#### Documentation

- **`docs/about/about_DattoRMM.CoreThrottling.md`** — Rewrote Delay Behaviour, Calibration, and Concurrent Use sections; added stability-adaptive calibration explanation; corrected and extended profile parameter table
- **`.github/agents/`** — Added `throttle-engineer.agent.md` and `throttle-analyst.agent.md` specialist agent definitions

---

### Validation

Validated via 12 Rd3 test runs (3 profiles × 2 expressions × x1/x4 concurrency):

| Result | Value |
|---|---|
| Pause events | **0** across all 12 runs |
| Errors | **0** across all 12 runs |
| Calibration interval extension | Confirmed: 5s → 20s (Cautious), 5s → 10s ceiling (Aggressive) |
| Max throughput regression vs Rd2 | **−1.7%** (within noise) |
| Worker balance (x4 runs) | All ≤ 1.21:1 |