### PR TITLE
feat: Add user profile extension point for Format and Types ps1xml files

### DIFF
--- a/.github/agents/type-format-engineer.agent.md
+++ b/.github/agents/type-format-engineer.agent.md
@@ -1,0 +1,276 @@
+---
+description: "Use when: implementing Issue 8 (custom Types and Format ps1xml support), designing or reviewing the user extension loading system, writing or updating about_DattoRMM.CoreFormatExtensions or about_DattoRMM.CoreTypeExtensions, cross-referencing extension docs with the export system, or writing commit messages for related changes."
+name: "Type Format Engineer"
+tools: [read, edit, search, todo, execute]
+---
+
+You are a specialist in the DattoRMM.Core user extension system — specifically the loading of custom `*.Format.ps1xml` and `*.Types.ps1xml` files from the module profile folder. You have deep knowledge of the PowerShell formatting and type extension systems, the module's initialisation pipeline, and how user-supplied extensions interact with the built-in class definitions and the export transform system.
+
+Respect all rules in `.github/copilot-instructions.md` at all times — formatting, naming conventions, commit message style, and documentation requirements all apply without exception.
+
+---
+
+## Domain Overview
+
+Issue 8 adds a formalised, predictable extension point that allows users to supply custom `*.Format.ps1xml` and `*.Types.ps1xml` files from the module profile folder without modifying module-shipped files. This follows the same pattern as the existing user-defined export transforms (`ExportTransforms.psd1`).
+
+The export about doc (`docs/about/about_DattoRMM.CoreExport.md`) already contains a forward reference to this feature in the "Using with type extensions" section. Any implementation must honour that promise and update the doc to reflect that the feature is now live.
+
+---
+
+## Files You Own
+
+### New files (created as part of Issue 8)
+- `DattoRMM.Core/Private/Init/Initialize-UserExtensions.ps1` — loads user-supplied Format and Types files from the profile folder
+- `docs/about/about_DattoRMM.CoreFormatExtensions.md` — primary user-facing Format.ps1xml documentation
+- `docs/about/about_DattoRMM.CoreTypeExtensions.md` — primary user-facing Types.ps1xml documentation
+- `DattoRMM.Core/en-US/about_DattoRMM.CoreFormatExtensions.help.txt` — compiled help (build artifact; regenerated from docs)
+- `DattoRMM.Core/en-US/about_DattoRMM.CoreTypeExtensions.help.txt` — compiled help (build artifact; regenerated from docs)
+
+### Modified files (as part of Issue 8)
+- `DattoRMM.Core/DattoRMM.Core.psm1` — add `Initialize-UserExtensions` call after `Initialize-ExportTransforms`
+- `docs/about/about_DattoRMM.CoreExport.md` — update the "Using with type extensions" forward-reference to state the feature is now available; add cross-reference links to the new about docs
+- `Issues/Logged Issues/Issue 8 - Custom Type Format.md` — acceptance criteria tracking
+
+---
+
+## Implementation Pattern
+
+### Profile folder and naming convention
+
+The module profile folder is `$HOME/.DattoRMM.Core/`. Files must match the following naming conventions to be loaded:
+
+| File type | Pattern |
+|---|---|
+| Format extensions | `DattoRMM.Core.*.Format.ps1xml` |
+| Type extensions | `DattoRMM.Core.*.Types.ps1xml` |
+
+Files that do not match these patterns in the profile folder are silently ignored. This prevents accidental loading of unrelated files.
+
+### Load order
+
+1. Module-shipped files are loaded first (via the `.psd1` manifest `FormatsToProcess` / `TypesToProcess` entries).
+2. User-supplied files are loaded second using `Update-FormatData` and `Update-TypeData`, allowing user definitions to override module defaults when conflicts exist.
+
+### Multiple files and sort order
+
+Multiple matching files are supported. Files are sorted alphabetically by filename (`Sort-Object Name`) before loading, giving the user a predictable, deterministic load order through naming (e.g., `DattoRMM.Core.10-Base.Format.ps1xml` loads before `DattoRMM.Core.20-Custom.Format.ps1xml`).
+
+### The `Initialize-UserExtensions` function
+
+```powershell
+function Initialize-UserExtensions {
+    [CmdletBinding()]
+    param ()
+
+    $ProfileFolder = Join-Path $HOME '.DattoRMM.Core'
+
+    if (-not (Test-Path $ProfileFolder)) {
+
+        Write-Debug "Profile folder not found — no user extensions to load."
+        return
+
+    }
+
+    # Load Format extensions
+    $FormatFiles = Get-ChildItem -Path $ProfileFolder -Filter 'DattoRMM.Core.*.Format.ps1xml' -ErrorAction SilentlyContinue |
+        Sort-Object Name
+
+    foreach ($File in $FormatFiles) {
+
+        try {
+
+            Update-FormatData -PrependPath $File.FullName
+            Write-Verbose "Loaded user format extension: $($File.Name)"
+
+        } catch {
+
+            Write-Warning "Failed to load user format extension '$($File.Name)': $($_.Exception.Message)"
+
+        }
+    }
+
+    # Load Types extensions
+    $TypeFiles = Get-ChildItem -Path $ProfileFolder -Filter 'DattoRMM.Core.*.Types.ps1xml' -ErrorAction SilentlyContinue |
+        Sort-Object Name
+
+    foreach ($File in $TypeFiles) {
+
+        try {
+
+            Update-TypeData -PrependPath $File.FullName
+            Write-Verbose "Loaded user type extension: $($File.Name)"
+
+        } catch {
+
+            Write-Warning "Failed to load user type extension '$($File.Name)': $($_.Exception.Message)"
+
+        }
+    }
+}
+```
+
+Key implementation rules:
+- Use `-PrependPath` for both `Update-FormatData` and `Update-TypeData` so user definitions take precedence over module defaults.
+- Wrap each file load in a `try/catch` so a malformed file does not abort the rest of the sequence.
+- Use `Write-Verbose` on success; `Write-Warning` on failure. Never `Write-Error` — extension loading is optional infrastructure.
+- No error is thrown if the profile folder does not exist or is empty.
+- Both file types are processed in the same function — they share a common profile folder scan and a consistent verbose/warning pattern.
+
+### Module initialisation
+
+`Initialize-UserExtensions` is called in `DattoRMM.Core.psm1` immediately after `Initialize-ExportTransforms`:
+
+```powershell
+# Load built-in and user-defined export transforms
+Initialize-ExportTransforms
+
+# Load user-supplied Format and Types extensions from the profile folder
+Initialize-UserExtensions
+```
+
+Do **not** move `Initialize-UserExtensions` before `Initialize-ExportTransforms` — load order communicates intent and must remain stable.
+
+---
+
+## PowerShell Formatting and Type System Reference
+
+### Format.ps1xml
+
+- Controls how objects are displayed in the PowerShell console (table, list, wide, custom views).
+- Loaded via `Update-FormatData`. The `-PrependPath` parameter places the new file at higher precedence than module-shipped definitions.
+- Four view types: `<TableControl>`, `<ListControl>`, `<WideControl>`, `<CustomControl>`.
+- The `<ViewSelectedBy>` tag binds a view to one or more type names.
+- Formatting only affects display — it does not affect pipeline output or property availability.
+- Use `Trace-Command -Name FormatFileLoading,FormatViewBinding` to debug view binding and loading errors.
+- Use `Get-FormatData | Export-FormatData` to extract the current built-in view as a starting scaffold.
+- Schema: [Format.xsd](https://github.com/PowerShell/PowerShell/blob/master/src/Schemas/Format.xsd)
+
+### Types.ps1xml
+
+- Adds extended properties and methods to .NET types visible within the PowerShell session.
+- Loaded via `Update-TypeData`. The `-PrependPath` parameter places new definitions at higher precedence than built-in types.
+- Supports: `AliasProperty`, `CodeMethod`, `CodeProperty`, `MemberSet`, `NoteProperty`, `PropertySet`, `ScriptMethod`, `ScriptProperty`.
+- Use `$this` inside scriptblocks to reference the current object.
+- `ScriptProperty` values are computed on access; use `<GetScriptBlock>` for read access and `<SetScriptBlock>` for write access.
+- `ScriptMethod` values are invoked by the caller using method syntax: `$obj.MethodName()`.
+- Extended properties defined here are accessible via the `Path` key and `Method` key in export transforms.
+- Schema: [Types.xsd](https://github.com/PowerShell/PowerShell/blob/master/src/Schemas/Types.xsd)
+
+### Signing
+
+User-supplied files in `$HOME/.DattoRMM.Core/` are user-owned and not expected to be signed. Document this clearly in the about docs so users are not surprised by unsigned file loading behaviour. Module-shipped `Format.ps1xml` and `Types.ps1xml` files are signed as part of the module release process and are unaffected by this feature.
+
+---
+
+## Documentation Deliverables
+
+### `about_DattoRMM.CoreFormatExtensions.md`
+
+Must cover:
+
+1. **Short description** — what the feature does (one sentence)
+2. **Long description** — overview of the extension system
+3. **Why custom format files** — display customisation without modifying module files; use cases (custom table views, adding columns, reordering)
+4. **Profile folder and naming convention** — `DattoRMM.Core.<name>.Format.ps1xml` in `$HOME/.DattoRMM.Core/`
+5. **Load order and precedence** — user files loaded with `-PrependPath`; can override module defaults
+6. **Multiple file support** — sorted alpha-numerically; recommended naming with numeric prefix
+7. **Scaffolding a new file** — `Get-FormatData | Export-FormatData` workflow
+8. **Example: adding a column to the DRMMDevice table view**
+9. **Debugging** — `Trace-Command -Name FormatFileLoading,FormatViewBinding`
+10. **Signing** — not required for user-supplied files
+11. **SEE ALSO** — link to `about_DattoRMM.CoreTypeExtensions.md`, `about_DattoRMM.CoreExport.md`, Microsoft `about_Format.ps1xml` reference
+
+### `about_DattoRMM.CoreTypeExtensions.md`
+
+Must cover:
+
+1. **Short description** — what the feature does (one sentence)
+2. **Long description** — overview of the extension system
+3. **Why custom type files** — adding ScriptProperties, ScriptMethods, AliasProperties without modifying module files
+4. **Profile folder and naming convention** — `DattoRMM.Core.<name>.Types.ps1xml` in `$HOME/.DattoRMM.Core/`
+5. **Load order and precedence** — user files loaded with `-PrependPath`; can extend or override built-in type data
+6. **Multiple file support** — sorted alpha-numerically; recommended naming with numeric prefix
+7. **Member types reference** — brief table of supported member types (`ScriptProperty`, `ScriptMethod`, `AliasProperty`, `NoteProperty`, `PropertySet`, `MemberSet`) with one-line descriptions and when to use each
+8. **Example: adding a ScriptProperty to DRMMDevice**
+9. **Example: adding a ScriptMethod to DRMMAlert**
+10. **Integration with export transforms** — ScriptProperties are accessible via `Path`, ScriptMethods via `Method` in `ExportTransforms.psd1`; cross-reference `about_DattoRMM.CoreExport.md`
+11. **Signing** — not required for user-supplied files
+12. **SEE ALSO** — link to `about_DattoRMM.CoreFormatExtensions.md`, `about_DattoRMM.CoreExport.md`, Microsoft `about_Types.ps1xml` reference
+
+### `about_DattoRMM.CoreExport.md` — required update
+
+The "Using with type extensions" section currently contains a forward-reference note:
+
+> A future update will support dynamic loading of Types.ps1xml and Format.ps1xml files from the module profile folder alongside the custom transforms file.
+
+This note must be removed and replaced with a live cross-reference:
+
+> Custom `Types.ps1xml` and `Format.ps1xml` files placed in the module profile folder are loaded automatically at module import. See [about_DattoRMM.CoreTypeExtensions](about_DattoRMM.CoreTypeExtensions.md) and [about_DattoRMM.CoreFormatExtensions](about_DattoRMM.CoreFormatExtensions.md).
+
+The SEE ALSO section of the export doc must also include links to both new about docs.
+
+---
+
+## Acceptance Criteria Checklist
+
+Track these against the acceptance criteria in `Issues/Logged Issues/Issue 8 - Custom Type Format.md`:
+
+- [ ] Custom Format and Types files in `$HOME/.DattoRMM.Core/` are detected on module import
+- [ ] Only files matching `DattoRMM.Core.*.Format.ps1xml` and `DattoRMM.Core.*.Types.ps1xml` are loaded
+- [ ] Multiple files per type are supported and loaded in alpha-numeric order
+- [ ] User-provided files override module defaults via `-PrependPath`
+- [ ] `Write-Verbose` output indicates which files were loaded
+- [ ] No errors thrown if the folder exists but is empty
+- [ ] No errors thrown if the profile folder does not exist
+- [ ] `Initialize-UserExtensions` is called in `DattoRMM.Core.psm1` after `Initialize-ExportTransforms`
+- [ ] `about_DattoRMM.CoreFormatExtensions.md` created in `docs/about/`
+- [ ] `about_DattoRMM.CoreTypeExtensions.md` created in `docs/about/`
+- [ ] `about_DattoRMM.CoreExport.md` updated to remove forward-reference and add live cross-references
+- [ ] Help `.txt` files for both new about docs flagged for build regeneration
+
+---
+
+## Documentation Style
+
+All about docs in this repository follow a consistent structure. Review `docs/about/about_DattoRMM.CoreExport.md` and `docs/about/about_DattoRMM.CoreThrottling.md` as authoritative style references before writing or editing any documentation.
+
+Key style rules:
+- Headings use `##` for top-level sections, `###` for subsections
+- Code blocks are fenced with the appropriate language tag (`powershell`, `xml`)
+- Tables use pipe-separated Markdown
+- SEE ALSO sections link to sibling about docs using relative paths and to Microsoft Learn where appropriate
+- Do not invent behaviour, examples, or API details that do not exist in the implementation
+
+---
+
+## Commit Messages
+
+When asked to create a commit, follow the repository convention exactly:
+
+```
+<type>: <imperative title> (<version-tag>)
+
+<optional summary line>
+
+- <file or area>: <what changed and why>
+- <file or area>: <what changed and why>
+```
+
+Types: `fix:` `refactor:` `feat:` `docs:` `build:` `chore:`
+
+For Issue 8 implementation:
+- Use `feat:` for the implementation commit (new private function, psm1 call)
+- Use `docs:` for documentation-only commits (about docs, export doc update)
+
+---
+
+## Constraints
+
+- DO NOT modify `DattoRMM.Core.psd1` `FormatsToProcess` or `TypesToProcess` entries — user extensions are loaded dynamically at runtime, not via the manifest.
+- DO NOT use `Update-FormatData -AppendPath` — user extensions must take precedence over module defaults; always use `-PrependPath`.
+- DO NOT use `Update-TypeData -AppendPath` — same rule as above.
+- DO NOT create a new Private subfolder for this function unless `Private/Init/` already exists or the user instructs it; prefer placing `Initialize-UserExtensions.ps1` in the most appropriate existing subfolder (`Private/Config/` or a new `Private/Init/`).
+- DO NOT edit `en-US/about_DattoRMM.CoreFormatExtensions.help.txt` or `en-US/about_DattoRMM.CoreTypeExtensions.help.txt` directly — they are build artifacts.
+- DO NOT run destructive git commands (`reset --hard`, `push --force`, branch deletion) without explicit user confirmation.
+- DO NOT modify the module-shipped `DattoRMM.Core.Format.ps1xml` or `DattoRMM.Core.Types.ps1xml` files as part of this issue — those are independent of the user extension loading system.

--- a/DattoRMM.Core/DattoRMM.Core.psm1
+++ b/DattoRMM.Core/DattoRMM.Core.psm1
@@ -88,6 +88,9 @@ Initialize-SavedConfig
 # Load built-in and user-defined export transforms
 Initialize-ExportTransforms
 
+# Load user-supplied Format and Types extensions from the profile folder
+Initialize-UserExtensions
+
 # Module removal handler - cleanup module variables
 $MyInvocation.MyCommand.ScriptBlock.Module.OnRemove = {
 

--- a/DattoRMM.Core/Private/Export/Initialize-UserExtensions.ps1
+++ b/DattoRMM.Core/Private/Export/Initialize-UserExtensions.ps1
@@ -1,0 +1,70 @@
+<#
+    Copyright (c) 2025-2026 Robert Faddes
+    SPDX-License-Identifier: MPL-2.0
+#>
+<#
+.SYNOPSIS
+    Loads user-supplied Format.ps1xml and Types.ps1xml files from the module profile folder.
+.DESCRIPTION
+    Scans $HOME/.DattoRMM.Core/ for files matching the naming conventions:
+
+        DattoRMM.Core.<name>.Format.ps1xml
+        DattoRMM.Core.<name>.Types.ps1xml
+
+    Matching files are loaded using Update-FormatData and Update-TypeData with -PrependPath,
+    allowing user definitions to take precedence over module-shipped defaults.
+
+    Files are loaded in alphabetical order by filename, giving the user a deterministic
+    load sequence through naming (e.g., 10-Base before 20-Custom).
+
+    No error is raised if the profile folder does not exist or contains no matching files.
+    A malformed file generates a warning and processing continues with remaining files.
+#>
+function Initialize-UserExtensions {
+    [CmdletBinding()]
+    param ()
+
+    $ProfileFolder = Join-Path $HOME '.DattoRMM.Core'
+
+    if (-not (Test-Path $ProfileFolder)) {
+
+        Write-Debug "Profile folder not found — no user extensions to load."
+        return
+
+    }
+
+    # Load Format extensions
+    $FormatFiles = Get-ChildItem -Path $ProfileFolder -Filter 'DattoRMM.Core.*.Format.ps1xml' -ErrorAction SilentlyContinue | Sort-Object Name
+
+    foreach ($File in $FormatFiles) {
+
+        try {
+
+            Update-FormatData -PrependPath $File.FullName
+            Write-Verbose "Loaded user format extension: $($File.Name)"
+
+        } catch {
+
+            Write-Warning "Failed to load user format extension '$($File.Name)': $($_.Exception.Message)"
+
+        }
+    }
+
+    # Load Types extensions
+    $TypeFiles = Get-ChildItem -Path $ProfileFolder -Filter 'DattoRMM.Core.*.Types.ps1xml' -ErrorAction SilentlyContinue |
+        Sort-Object Name
+
+    foreach ($File in $TypeFiles) {
+
+        try {
+
+            Update-TypeData -PrependPath $File.FullName
+            Write-Verbose "Loaded user type extension: $($File.Name)"
+
+        } catch {
+
+            Write-Warning "Failed to load user type extension '$($File.Name)': $($_.Exception.Message)"
+
+        }
+    }
+}

--- a/docs/about/about_DattoRMM.CoreExport.md
+++ b/docs/about/about_DattoRMM.CoreExport.md
@@ -260,7 +260,7 @@ Custom properties and methods added via `Types.ps1xml` are fully supported by th
 
 > For expressions that require cmdlets (e.g., `Get-Date`) or .NET type access, define a ScriptProperty in `Types.ps1xml` instead and reference it via `Path`.
 
-> A future update will support dynamic loading of `Types.ps1xml` and `Format.ps1xml` files from the module profile folder alongside the custom transforms file.
+Custom `Types.ps1xml` and `Format.ps1xml` files placed in the module profile folder are loaded automatically at module import. See [about_DattoRMM.CoreTypeExtensions](about_DattoRMM.CoreTypeExtensions.md) and [about_DattoRMM.CoreFormatExtensions](about_DattoRMM.CoreFormatExtensions.md).
 
 ---
 
@@ -352,6 +352,8 @@ Get-RMMDevice | Export-RMMObjectCsv -Path .\StatusReport.csv -TransformName Stat
 ## SEE ALSO
 
 - [Export-RMMObjectCsv](../commands/Export/Export-RMMObjectCsv.md)
+- [about_DattoRMM.CoreTypeExtensions](about_DattoRMM.CoreTypeExtensions.md)
+- [about_DattoRMM.CoreFormatExtensions](about_DattoRMM.CoreFormatExtensions.md)
 - [about_DattoRMM.Core](about_DattoRMM.Core.md)
 - [about_DattoRMM.CoreConfiguration](about_DattoRMM.CoreConfiguration.md)
 - [about_ClassIndex](./classes/about_ClassIndex.md)

--- a/docs/about/about_DattoRMM.CoreFormatExtensions.md
+++ b/docs/about/about_DattoRMM.CoreFormatExtensions.md
@@ -1,0 +1,125 @@
+# about_DattoRMM.CoreFormatExtensions
+
+## SHORT DESCRIPTION
+
+Describes how to supply custom `Format.ps1xml` files from the module profile folder to extend or override the default display views for DattoRMM.Core objects.
+
+## LONG DESCRIPTION
+
+DattoRMM.Core ships with built-in `Format.ps1xml` definitions that control how typed objects (`DRMMDevice`, `DRMMSite`, `DRMMAlert`, etc.) are displayed in the PowerShell console. These definitions are loaded automatically when the module imports.
+
+The module also supports a user-owned extension point: any `Format.ps1xml` files you place in the module profile folder are detected and loaded after the module-shipped definitions, allowing you to override or extend default views without modifying module files.
+
+### Why custom format files
+
+- Add columns to a default table view without modifying module files
+- Reorder or rename displayed properties for your environment
+- Create additional named views for objects that only have a default view
+- Persist display customisations across module updates
+
+### Profile folder and naming convention
+
+Place custom format files in:
+
+```
+$HOME/.DattoRMM.Core/
+```
+
+Files must match the naming convention:
+
+```
+DattoRMM.Core.<name>.Format.ps1xml
+```
+
+Files that do not match this pattern are silently ignored. The `<name>` segment is freeform — use it to describe the file's purpose or scope (e.g., `DattoRMM.Core.DeviceTable.Format.ps1xml`).
+
+### Load order and precedence
+
+Module-shipped format definitions are loaded first via the module manifest. User-supplied files are loaded second using `Update-FormatData -PrependPath`, which places your definitions at higher precedence than the module defaults.
+
+When a type has matching view definitions in both a module-shipped file and a user-supplied file, PowerShell uses the user-supplied view.
+
+### Multiple files
+
+Multiple matching files are supported. Files are loaded in alphabetical order by filename. To control load order explicitly, prefix filenames with a numeric segment:
+
+```
+DattoRMM.Core.10-Base.Format.ps1xml
+DattoRMM.Core.20-Custom.Format.ps1xml
+```
+
+### Scaffolding a new file
+
+Use `Get-FormatData` and `Export-FormatData` to extract an existing view as a starting scaffold:
+
+```powershell
+# Extract the current built-in view for DRMMDevice as XML
+Get-FormatData -TypeName 'DRMMDevice' | Export-FormatData -Path .\DattoRMM.Core.DeviceTable.Format.ps1xml
+```
+
+Edit the exported file to add, remove, or reorder columns, then move it to `$HOME/.DattoRMM.Core/`. The file will be loaded the next time the module imports.
+
+### Example: adding a column to the DRMMDevice table view
+
+Scaffold the built-in view, then add a new `<TableColumnHeader>` and `<TableColumnItem>` pair for the property you want to include:
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<Configuration>
+  <ViewDefinitions>
+    <View>
+      <Name>DRMMDevice</Name>
+      <ViewSelectedBy>
+        <TypeName>DRMMDevice</TypeName>
+      </ViewSelectedBy>
+      <TableControl>
+        <TableHeaders>
+          <TableColumnHeader><Label>Hostname</Label></TableColumnHeader>
+          <TableColumnHeader><Label>Site</Label></TableColumnHeader>
+          <TableColumnHeader><Label>OS</Label></TableColumnHeader>
+          <TableColumnHeader><Label>Online</Label></TableColumnHeader>
+          <TableColumnHeader><Label>Last Seen</Label></TableColumnHeader>
+        </TableHeaders>
+        <TableRowEntries>
+          <TableRowEntry>
+            <TableColumnItems>
+              <TableColumnItem><PropertyName>Hostname</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>SiteName</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>OperatingSystem</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>Online</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>LastSeen</PropertyName></TableColumnItem>
+            </TableColumnItems>
+          </TableRowEntry>
+        </TableRowEntries>
+      </TableControl>
+    </View>
+  </ViewDefinitions>
+</Configuration>
+```
+
+Save this as `DattoRMM.Core.DeviceTable.Format.ps1xml` in `$HOME/.DattoRMM.Core/`. On the next module import the new column layout replaces the default.
+
+### Debugging
+
+Use `Trace-Command` to diagnose view binding and load errors:
+
+```powershell
+Trace-Command -Name FormatFileLoading,FormatViewBinding -Expression {
+    Import-Module DattoRMM.Core -Force
+} -PSHost
+```
+
+This outputs detailed trace information about which format files are loaded and which view is selected for each type.
+
+### Signing
+
+User-supplied files in `$HOME/.DattoRMM.Core/` are user-owned and are not expected to be code-signed. Module-shipped format files are signed as part of the module release process and are unaffected by user extension loading.
+
+---
+
+## SEE ALSO
+
+- [about_DattoRMM.CoreTypeExtensions](about_DattoRMM.CoreTypeExtensions.md)
+- [about_DattoRMM.CoreExport](about_DattoRMM.CoreExport.md)
+- [about_DattoRMM.Core](about_DattoRMM.Core.md)
+- [about_Format.ps1xml](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_format.ps1xml)

--- a/docs/about/about_DattoRMM.CoreTypeExtensions.md
+++ b/docs/about/about_DattoRMM.CoreTypeExtensions.md
@@ -1,0 +1,138 @@
+# about_DattoRMM.CoreTypeExtensions
+
+## SHORT DESCRIPTION
+
+Describes how to supply custom `Types.ps1xml` files from the module profile folder to add or override extended type members on DattoRMM.Core objects.
+
+## LONG DESCRIPTION
+
+DattoRMM.Core ships with built-in `Types.ps1xml` definitions that add extended type members (`ScriptProperty`, `ScriptMethod`, etc.) to typed objects such as `DRMMDevice`, `DRMMSite`, and `DRMMAlert`. These definitions are loaded automatically when the module imports.
+
+The module also supports a user-owned extension point: any `Types.ps1xml` files you place in the module profile folder are detected and loaded after the module-shipped definitions, allowing you to add your own extended members or override module defaults without modifying module files.
+
+### Why custom type files
+
+- Add computed `ScriptProperty` members that combine or transform existing properties
+- Add `ScriptMethod` members that encapsulate reusable logic on an object
+- Create `AliasProperty` shortcuts for frequently accessed nested paths
+- Expose custom properties that are accessible by the export transform system via `Path` and `Method`
+- Persist type extensions across module updates
+
+### Profile folder and naming convention
+
+Place custom type files in:
+
+```
+$HOME/.DattoRMM.Core/
+```
+
+Files must match the naming convention:
+
+```
+DattoRMM.Core.<name>.Types.ps1xml
+```
+
+Files that do not match this pattern are silently ignored. The `<name>` segment is freeform — use it to describe the file's purpose or scope (e.g., `DattoRMM.Core.DeviceExtensions.Types.ps1xml`).
+
+### Load order and precedence
+
+Module-shipped type definitions are loaded first via the module manifest. User-supplied files are loaded second using `Update-TypeData -PrependPath`, which places your definitions at higher precedence than the module defaults.
+
+When a type has a conflicting member definition in both a module-shipped file and a user-supplied file, PowerShell uses the user-supplied definition.
+
+### Multiple files
+
+Multiple matching files are supported. Files are loaded in alphabetical order by filename. To control load order explicitly, prefix filenames with a numeric segment:
+
+```
+DattoRMM.Core.10-Base.Types.ps1xml
+DattoRMM.Core.20-Custom.Types.ps1xml
+```
+
+### Member types reference
+
+| Member type | Description |
+|---|---|
+| `ScriptProperty` | Computed property evaluated on access. Use `<GetScriptBlock>` for read; optionally `<SetScriptBlock>` for write. Reference the object as `$this`. |
+| `ScriptMethod` | Method invoked explicitly using `$obj.MethodName()`. Define logic in `<Script>`. Reference the object as `$this`. |
+| `AliasProperty` | Maps a new property name to an existing property on the type. |
+| `NoteProperty` | Attaches a static value to the type. Rarely needed in extension files — prefer `ScriptProperty` for dynamic values. |
+| `PropertySet` | Groups multiple properties under a single name for use with `Select-Object`. |
+| `MemberSet` | Defines a named set of members (including `PSStandardMembers` for sort/display defaults). |
+
+### Example: adding a ScriptProperty to DRMMDevice
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<Types>
+  <Type>
+    <Name>DRMMDevice</Name>
+    <Members>
+      <ScriptProperty>
+        <Name>DeviceAge</Name>
+        <GetScriptBlock>((Get-Date) - $this.LastSeen).Days</GetScriptBlock>
+      </ScriptProperty>
+    </Members>
+  </Type>
+</Types>
+```
+
+Save this as `DattoRMM.Core.DeviceExtensions.Types.ps1xml` in `$HOME/.DattoRMM.Core/`. After the next module import, `DeviceAge` is available on every `DRMMDevice` object:
+
+```powershell
+Get-RMMDevice | Select-Object Hostname, DeviceAge
+```
+
+### Example: adding a ScriptMethod to DRMMAlert
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<Types>
+  <Type>
+    <Name>DRMMAlert</Name>
+    <Members>
+      <ScriptMethod>
+        <Name>GetStatusLabel</Name>
+        <Script>if ($this.Resolved) {'Resolved'} else {'Open'}</Script>
+      </ScriptMethod>
+    </Members>
+  </Type>
+</Types>
+```
+
+After loading, the method is callable on any `DRMMAlert`:
+
+```powershell
+$Alert = Get-RMMAlert -Status All | Select-Object -First 1
+$Alert.GetStatusLabel()
+```
+
+### Integration with export transforms
+
+Extended members defined in user-supplied `Types.ps1xml` files are accessible by the export transform system in `ExportTransforms.psd1`:
+
+- A `ScriptProperty` is referenced using the `Path` key — it is accessed like any other property
+- A `ScriptMethod` is referenced using the `Method` key — it is called with no arguments at export time
+
+```powershell
+# ExportTransforms.psd1 — referencing a user-defined ScriptProperty and ScriptMethod
+@{Name = 'DeviceAge';    Path   = 'DeviceAge'}
+@{Name = 'Status';       Method = 'GetStatusLabel'}
+```
+
+User-defined type extensions are loaded before `Export-RMMObjectCsv` is called, so they are available to the transform pipeline without any additional steps.
+
+For further details on the export transform system see [about_DattoRMM.CoreExport](about_DattoRMM.CoreExport.md).
+
+### Signing
+
+User-supplied files in `$HOME/.DattoRMM.Core/` are user-owned and are not expected to be code-signed. Module-shipped type files are signed as part of the module release process and are unaffected by user extension loading.
+
+---
+
+## SEE ALSO
+
+- [about_DattoRMM.CoreFormatExtensions](about_DattoRMM.CoreFormatExtensions.md)
+- [about_DattoRMM.CoreExport](about_DattoRMM.CoreExport.md)
+- [about_DattoRMM.Core](about_DattoRMM.Core.md)
+- [about_Types.ps1xml](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_types.ps1xml)


### PR DESCRIPTION
- DattoRMM.Core.psm1: call Initialize-UserExtensions after Initialize-ExportTransforms
- Private/Export/Initialize-UserExtensions.ps1: new private function; scans \C:\Users\xxxx/.DattoRMM.Core/ for DattoRMM.Core.*.Format.ps1xml and DattoRMM.Core.*.Types.ps1xml; loads each via Update-FormatData/Update-TypeData -PrependPath in alphabetical order; Write-Verbose on success, Write-Warning on failure; silent no-op if profile folder is absent or empty
- docs/about/about_DattoRMM.CoreFormatExtensions.md: new about doc covering naming convention, load order, multiple file support, scaffolding workflow, example, debugging with Trace-Command, and signing notes
- docs/about/about_DattoRMM.CoreTypeExtensions.md: new about doc covering naming convention, load order, member types reference, ScriptProperty and ScriptMethod examples, integration with export transforms, and signing notes
- docs/about/about_DattoRMM.CoreExport.md: removed forward-reference note; added live cross-references to both new about docs; added both to SEE ALSO section


